### PR TITLE
overhaul

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,8 +2,9 @@
 
 * Unit creation has been significantly refactored. `units<-` now accepts strings
 or quoted language objects on the right hand side, powered by new S3 methods for
-`as_units`. New user facing function `make_units()` (plural s) is also provided.
-See `?as_units` for details. @t-kalinowski
+`as_units`. All valid unit symbols and unit names recognized by package 'udunits2' are 
+now accepted. New user facing function `make_units()` (plural s) is also
+provided. See `?as_units` for details. @t-kalinowski
 
 * new functions `valid_udunits()` and `valid_udunits_prefixes()` generate tidy
 dataframes listing all the valid unit names, symbols, and prefixes recognized by

--- a/R/arith.R
+++ b/R/arith.R
@@ -155,8 +155,8 @@ Ops.units <- function(e1, e2) {
 #' a = set_units(1:5, m)
 #' a %*% a
 #' a %*% t(a)
-#' a %*% set_units(1:5, set_units(1))
-#' set_units(1:5, set_units(1)) %*% a
+#' a %*% set_units(1:5, 1)
+#' set_units(1:5, 1) %*% a
 `%*%.units` = function(x, y) {
 	ret = `%*%.default`(unclass(x), unclass(y))
 	units(ret) = .multiply_symbolic_units(1, units(x), units(y))

--- a/R/make_units.R
+++ b/R/make_units.R
@@ -333,10 +333,10 @@ See ?as_units for usage examples.")
   names(vars) <- vars
   tmp_env <- lapply(vars, symbolic_unit, check_is_valid = FALSE)
   
-  unit <- try(eval(x, tmp_env, units_eval_env), silent = TRUE)
-  if(inherits(unit, "try-error"))
-    stop(paste0(unit, "\n", 
-      "Did you try to supply a value in a context where a bare expression was expected?"))
+  unit <- tryCatch( eval(x, tmp_env, units_eval_env),
+    error = function(e) stop( paste0( conditionMessage(e), "\n",
+          "Did you try to supply a value in a context where a bare expression was expected?"
+        ), call. = FALSE ))
   
   if(as.numeric(unit) %not_in% c(1, 0)) # 0 if log() used. 
     stop(call. = FALSE,

--- a/R/make_units.R
+++ b/R/make_units.R
@@ -151,7 +151,7 @@ are_exponents_implicit <- function(s) {
   s <- trimws(s)
   has <- function(chr, regex = FALSE) 
     grepl(chr, s, fixed = !regex, perl = regex)
-  !has("^") && !has("*") && !has("/") && has("\\s|\\d$", regex = TRUE)
+  !has("^") && !has("*") && !has("/") && has("\\s|\\D.*\\d$", regex = TRUE)
 }
 
 is_udunits_time <- function(s) {
@@ -312,16 +312,17 @@ units_eval_env$lb <- function(x) base::log(x, base = 2)
 #' @seealso \code{\link{valid_udunits}}
 as_units.call <- function(x, check_is_valid = TRUE, ...) {
   
-  stopifnot(is.language(x))
-  
-  if(missing(x) || tryCatch(eval(x, baseenv()) == 1, error = function(e) FALSE))
+  if(missing(x) || identical(x, quote(expr =)) || 
+     identical(x, 1) || identical(x, 1L))
     return(structure(1, units = unitless, class = "units"))
+  
+  stopifnot(is.language(x))
   
   vars <- all.vars(x)
   if(!length(vars))
     stop(call. = FALSE,
 "No symbols found. Please supply bare expressions with this approach.
-See ?as_units for alternative ways of creating units (e.g., from strings)")
+See ?as_units for usage examples.")
   
   if (check_is_valid) {
     valid <- vapply(vars, is_valid_unit_symbol, logical(1L))

--- a/R/make_units.R
+++ b/R/make_units.R
@@ -314,7 +314,7 @@ as_units.call <- function(x, check_is_valid = TRUE, ...) {
   
   stopifnot(is.language(x))
   
-  if(missing(x))
+  if(missing(x) || tryCatch(eval(x, baseenv()) == 1, error = function(e) FALSE))
     return(structure(1, units = unitless, class = "units"))
   
   vars <- all.vars(x)

--- a/R/make_units.R
+++ b/R/make_units.R
@@ -339,9 +339,8 @@ See ?as_units for usage examples.")
       "Did you try to supply a value in a context where a bare expression was expected?"))
   
   if(as.numeric(unit) %not_in% c(1, 0)) # 0 if log() used. 
-    warning(call. = FALSE,
-"In ", sQuote(deparse(x)), " the numeric multiplier ", sQuote(as.numeric(unit)), " was discarded. 
-The returned unit object was coerced to a value of 1.
+    stop(call. = FALSE,
+"In ", sQuote(deparse(x)), " the numeric multiplier ", sQuote(as.numeric(unit)), " is invalid. 
 Use `install_conversion_constant()` to define a new unit that is a multiple of another unit.")
   
   structure(1, units = units(unit), class = "units")

--- a/R/set_units.R
+++ b/R/set_units.R
@@ -32,9 +32,8 @@ set_units <- function(x, value, ...,
   }
   
   if (is.null(value))
-    drop_units(x)
-  else {
-    units(x) <- as_units(value, ...)
-    x
-  }
+    return(drop_units(x))
+  
+  units(x) <- as_units(value, ...)
+  x
 }

--- a/R/set_units.R
+++ b/R/set_units.R
@@ -9,17 +9,19 @@
 #'
 #' @param value a \code{units} object, or something coercible to one with
 #'   \code{as_units}. Depending on \code{mode}, the unit is constructed from the
-#'   supplied bare expression or from the supplied value via standard evaluation.
+#'   supplied bare expression or from the supplied value via standard
+#'   evaluation.
 #'
 #' @param ... passed on to \code{as_units}
 #'
 #' @param mode if \code{"symbols"} (the default), then unit is constructed from
-#'   the bare expression supplied. Otherwise, if\code{mode = "standard"},
+#'   the expression supplied. Otherwise, if\code{mode = "standard"},
 #'   standard evaluation is used for the supplied value This argument can be set
 #'   via a global option \code{options(units.set_units_mode = "standard")}
 #'
 #' @export
 #' @rdname set_units
+#' @seealso \code{\link{as_units}}
 set_units <- function(x, value, ...,
   mode = getOption("units.set_units_mode", c("symbols", "standard"))) {
   

--- a/R/set_units.R
+++ b/R/set_units.R
@@ -25,8 +25,11 @@ set_units <- function(x, value, ...,
   
   if (missing(value))
     value <- unitless
-  else if (match.arg(mode) == "symbols")
+  else if (match.arg(mode) == "symbols") {
     value <- substitute(value)
+    # if(class(value) == "character")
+    #   stop("Please set `mode = standard` to supply character strings as units")
+  }
   
   if (is.null(value))
     drop_units(x)

--- a/R/set_units.R
+++ b/R/set_units.R
@@ -31,8 +31,6 @@ set_units <- function(x, value, ...,
     if(is.numeric(value) && value != 1)
       stop("The only valid number defining a unit is '1', signifying a unitless unit")
     
-    if(identical(value, quote(unitless)))
-      value <- 1
   }
   
   if (is.null(value))

--- a/R/set_units.R
+++ b/R/set_units.R
@@ -27,8 +27,12 @@ set_units <- function(x, value, ...,
     value <- unitless
   else if (match.arg(mode) == "symbols") {
     value <- substitute(value)
-    # if(class(value) == "character")
-    #   stop("Please set `mode = standard` to supply character strings as units")
+    
+    if(is.numeric(value) && value != 1)
+      stop("The only valid number defining a unit is '1', signifying a unitless unit")
+    
+    if(identical(value, quote(unitless)))
+      value <- 1
   }
   
   if (is.null(value))

--- a/R/set_units.R
+++ b/R/set_units.R
@@ -28,9 +28,8 @@ set_units <- function(x, value, ...,
   else if (match.arg(mode) == "symbols") {
     value <- substitute(value)
     
-    if(is.numeric(value) && value != 1)
+    if(is.numeric(value) && !identical(value, 1) && !identical(value, 1L))
       stop("The only valid number defining a unit is '1', signifying a unitless unit")
-    
   }
   
   if (is.null(value))

--- a/man/matmult.Rd
+++ b/man/matmult.Rd
@@ -31,6 +31,6 @@ see \code{"\link[base]{\%*\%}"} for the base function, reimplemented
 a = set_units(1:5, m)
 a \%*\% a
 a \%*\% t(a)
-a \%*\% set_units(1:5, set_units(1))
-set_units(1:5, set_units(1)) \%*\% a
+a \%*\% set_units(1:5, 1)
+set_units(1:5, 1) \%*\% a
 }

--- a/man/set_units.Rd
+++ b/man/set_units.Rd
@@ -25,3 +25,6 @@ via a global option \code{options(units.set_units_mode = "standard")}}
 \description{
 A pipe friendly version of \code{units<-}
 }
+\seealso{
+\code{\link{as_units}}
+}

--- a/tests/testthat/test_unit_creation.R
+++ b/tests/testthat/test_unit_creation.R
@@ -111,10 +111,28 @@ test_that("various forms of unit creation and destruction work", {
   
 })
 
+test_that("unitless objects can be created", {
+  unit <- 1
+  units(unit) <-  units:::unitless
+  
+  xul <- x <- 2:5
+  units(xul) <-  units:::unitless
+  
+  
+  expect_identical(unit, make_units())
+  expect_identical(unit, make_units(1))
+  
+  expect_identical(unit, as_units(1))
+  expect_identical(unit, as_units("1"))
+  
+  expect_identical(xul, set_units(x, 1))
+  expect_identical(xul, set_units(x))
+  expect_identical(xul, set_units(x, "1"))
+  expect_identical(xul, set_units(x, "1", mode = "standard"))
+  expect_identical(xul, set_units(x, mode = "standard"))
+})
 
 test_that("set_units default enforces NSE", {
-  
-  
   expect_error(set_units(1:3, as_units("m")))
   expect_error(set_units(1:3, as_units("m/s")))
   expect_error(set_units(1:3, make_units(m)))
@@ -122,5 +140,4 @@ test_that("set_units default enforces NSE", {
   
   # is it bad if this works?
   # expect_error(set_units(1:3, "m/s"))
-                         
 })

--- a/tests/testthat/test_unit_creation.R
+++ b/tests/testthat/test_unit_creation.R
@@ -110,3 +110,17 @@ test_that("various forms of unit creation and destruction work", {
   expect_identical(meter_per_sec, as_units("m s-1"))
   
 })
+
+
+test_that("set_units default enforces NSE", {
+  
+  
+  expect_error(set_units(1:3, as_units("m")))
+  expect_error(set_units(1:3, as_units("m/s")))
+  expect_error(set_units(1:3, make_units(m)))
+  expect_error(set_units(1:3, make_units(m/s)))
+  
+  # is it bad if this works?
+  # expect_error(set_units(1:3, "m/s"))
+                         
+})


### PR DESCRIPTION
add make_units() parse_units().
refactor set_units(), no longer a generic
add symbolic_unit(), replaces make_unit()
depracate make_unit() and parse_unit() (singular 'unit' functions to reduce confusion)