### PR TITLE
alternative solution to #89; #91

### DIFF
--- a/R/init.R
+++ b/R/init.R
@@ -5,6 +5,7 @@
 NULL
 
 .onLoad = function(libname, pkgname) {
+  # can this be lozy loaded on first access attempt instead?
 	udunits_init(file.path(.get_ud_xml_dir(), "udunits2.xml"))
 }
 

--- a/R/init.R
+++ b/R/init.R
@@ -5,7 +5,7 @@
 NULL
 
 .onLoad = function(libname, pkgname) {
-	udunits_init(.get_ud_xml_dir())
+	udunits_init(file.path(.get_ud_xml_dir(), "udunits2.xml"))
 }
 
 .onAttach <- function(libname, pkgname) {

--- a/R/make_units.R
+++ b/R/make_units.R
@@ -285,12 +285,29 @@ units_eval_env$lb <- function(x) base::log(x, base = 2)
 
 units_eval_env$`/` <- function(x, y) {
   # don't cancel units, just combine them
+  if (!inherits(x, "units") || !inherits(y, "units"))
+    return(x/y)
+  
   units <- structure(list(
-    numerator = c(units(x)$numerator, units(y)$denominator), 
-    denominator = c(units(y)$numerator, units(x)$denominator)), 
+    numerator =   c(units(x)$numerator,   units(y)$denominator), 
+    denominator = c(units(x)$denominator, units(y)$numerator)), 
     class = "symbolic_units")
-  val <- as.numeric(x) / as.numeric(y)  #if(is.finite(y <- as.numeric(y))) y else 1
+  val <- drop_units(x) / drop_units(y)  
+  
   structure(val, units = units, class = "units")
+}
+
+units_eval_env$`*` <- function(x, y) {
+  if (!inherits(x, "units") || !inherits(y, "units"))
+    return(x * y)
+  
+  units <- structure(list(
+    numerator   = c(units(x)$numerator,   units(y)$numerator),
+    denominator = c(units(x)$denominator, units(y)$denominator)
+  ), class = "symbolic_units")
+  val <- drop_units(x) * drop_units(y)
+  structure(val, units = units, class = "units")
+  
 }
 
 

--- a/R/make_units.R
+++ b/R/make_units.R
@@ -283,6 +283,15 @@ units_eval_env$ln <- function(x) base::log(x)
 units_eval_env$lg <- function(x) base::log(x, base = 10)
 units_eval_env$lb <- function(x) base::log(x, base = 2)
 
+units_eval_env$`/` <- function(x, y) {
+  # don't cancel units, just combine them
+  units <- structure(list(
+    numerator = c(units(x)$numerator, units(y)$denominator), 
+    denominator = c(units(y)$numerator, units(x)$denominator)), 
+    class = "symbolic_units")
+  structure(1, units = units, class = "units")
+}
+
 
 #' @export
 #' @rdname as_units
@@ -338,10 +347,10 @@ See ?as_units for usage examples.")
           "Did you try to supply a value in a context where a bare expression was expected?"
         ), call. = FALSE ))
   
-#  if(as.numeric(unit) %not_in% c(1, 0)) # 0 if log() used. 
-#    stop(call. = FALSE,
-#"In ", sQuote(deparse(x)), " the numeric multiplier ", sQuote(as.numeric(unit)), " is invalid. 
-#Use `install_conversion_constant()` to define a new unit that is a multiple of another unit.")
+ if(as.numeric(unit) %not_in% c(1, 0)) # 0 if log() used.
+   stop(call. = FALSE,
+"In ", sQuote(deparse(x)), " the numeric multiplier ", sQuote(as.numeric(unit)), " is invalid.
+Use `install_conversion_constant()` to define a new unit that is a multiple of another unit.")
   
   structure(as.numeric(unit), units = units(unit), class = "units")
 }

--- a/R/make_units.R
+++ b/R/make_units.R
@@ -289,7 +289,8 @@ units_eval_env$`/` <- function(x, y) {
     numerator = c(units(x)$numerator, units(y)$denominator), 
     denominator = c(units(y)$numerator, units(x)$denominator)), 
     class = "symbolic_units")
-  structure(1, units = units, class = "units")
+  val <- as.numeric(x) / as.numeric(y)  #if(is.finite(y <- as.numeric(y))) y else 1
+  structure(val, units = units, class = "units")
 }
 
 
@@ -347,12 +348,12 @@ See ?as_units for usage examples.")
           "Did you try to supply a value in a context where a bare expression was expected?"
         ), call. = FALSE ))
   
- if(as.numeric(unit) %not_in% c(1, 0)) # 0 if log() used.
+ if(as.numeric(unit) %not_in% c(1, 0, Inf, NaN)) # 0, Inf, NaN if log() used.
    stop(call. = FALSE,
 "In ", sQuote(deparse(x)), " the numeric multiplier ", sQuote(as.numeric(unit)), " is invalid.
 Use `install_conversion_constant()` to define a new unit that is a multiple of another unit.")
   
-  structure(as.numeric(unit), units = units(unit), class = "units")
+  structure(1, units = units(unit), class = "units")
 }
 
 

--- a/R/valid_udunits.R
+++ b/R/valid_udunits.R
@@ -6,11 +6,11 @@
 }
 
 .get_ud_xml_dir <- function(warn = FALSE) {
-  paths = c(
+  paths = unique(c(
     Sys.getenv("UDUNITS2_XML_PATH"),
     "/usr/local/share/udunits/udunits2.xml",
     "/usr/share/xml/udunits/udunits2.xml",
-    "/usr/share/udunits/udunits2.xml")
+    "/usr/share/udunits/udunits2.xml"))
 
   fallback = system.file("share/udunits2.xml", package="units")
 

--- a/tests/testthat/test_conversion.R
+++ b/tests/testthat/test_conversion.R
@@ -139,11 +139,19 @@ test_that("dim propagates", {
 test_that("conversion to dimensionless with prefix works (g/kg)", {
 	a_orig <- a <- 1:10
 	units(a) = as_units("mg/kg")
-	expect_equal(as.numeric(a), a_orig/1e6)
+	# why should assigning units change the numeric value?
+	expect_equal(as.numeric(a), a_orig)
+	
 	units(a) = as_units("kg/mg")
-	expect_equal(a, a_orig)
+	expect_equal(a, a_orig/1e12)
+	
 	units(a) = as_units("g/g")
-	expect_equal(a, a_orig)
+	expect_equal(a, a_orig/1e6)
+	
 	units(a) = as_units("kg/g")
-	expect_equal(a, a_orig * 1000)
+	expect_equal(a, a_orig / 1e9)
+	
+	# back to original
+	units(a) <- as_units("mg/kg")
+	expect_equal(as.numeric(a), a_orig)
 })

--- a/tests/testthat/test_unit_creation.R
+++ b/tests/testthat/test_unit_creation.R
@@ -156,7 +156,6 @@ test_that("units composed of the same base unit don't cancel out", {
 })
 
 test_that("units with an arbritary numeric constants throw error", {
-  rt <- function(unit) as.character(units(as_units(unit)))
   
   test_cases <- c("20 * m", "m * 20", "20 * g/g", "g/ln(kg)/22",
                   "ln(g)/kg * 22", "ln(g)/g + 9", "ln(g)/ln(g) - 9")
@@ -164,4 +163,35 @@ test_that("units with an arbritary numeric constants throw error", {
   for(unit in test_cases)
     expect_error(as_units(test_cases))
   
+})
+
+
+
+test_that("variuos permutations of units are created properly", {
+  rt <- function(unit) as.character(units(as_units(unit)))
+ 
+  cases <- matrix(byrow = TRUE, ncol = 2, data = c(
+         "g/g"       , "g/g"     ,
+         "g*g/g"     , "g^2/g"   ,
+         "g^-1/g"    , "1/g^2"   ,
+         "g * g^-1"  , "g/g"     ,
+         "g^-1"      , "1/g"     ,
+         "1/g"       , "1/g"     ,
+         "g/(1/g)"   , "g^2"     ,
+         "1/g/g"     , "1/g^2"   
+  ))
+   
+  u_in <- cases[,1]
+  u_out <- cases[,2]
+  
+  for (r in 1:nrow(cases)) {
+    expect_equal(rt(u_in[r]), u_out[r])
+  }
+  
+   
+  # TODO units still cancel when parsing implicit exponents
+  # # ---- implicit exponents -----
+  # as_units("g  g-1") 
+  
+
 })

--- a/tests/testthat/test_unit_creation.R
+++ b/tests/testthat/test_unit_creation.R
@@ -143,3 +143,25 @@ test_that("set_units default enforces NSE", {
   # is it bad if this works?
   # expect_error(set_units(1:3, "m/s"))
 })
+
+test_that("units composed of the same base unit don't cancel out", {
+  rt <- function(unit) as.character(units(as_units(unit)))
+  
+  test_cases <- c("mg/kg", "g/kg", "g/g", "g/ln(kg)",
+                  "ln(g)/kg", "ln(g)/g", "ln(g)/ln(g)")
+  
+  for(unit in test_cases)
+    expect_equal(rt(unit), unit)
+
+})
+
+test_that("units with an arbritary numeric constants throw error", {
+  rt <- function(unit) as.character(units(as_units(unit)))
+  
+  test_cases <- c("20 * m", "m * 20", "20 * g/g", "g/ln(kg)/22",
+                  "ln(g)/kg * 22", "ln(g)/g + 9", "ln(g)/ln(g) - 9")
+  
+  for(unit in test_cases)
+    expect_error(as_units(test_cases))
+  
+})


### PR DESCRIPTION
With this implementation, the symbolic units are preserved so they can be printed correctly, and assigning a unit like "mg/kg" no longer changes the numeric value of the target vector.

Also, fixes the regression mentioned here (and elsewhere):
https://github.com/r-quantities/units/pull/64#issuecomment-339036324 
