### PR TITLE
use NextMethod for formatting and printing

### DIFF
--- a/R/summaries.R
+++ b/R/summaries.R
@@ -26,22 +26,17 @@ Summary.units = function(..., na.rm = FALSE) {
 }
 
 #' @export
-print.units <- function(x, digits = getOption("digits"), ...) # nocov start
-{
+print.units = function (x, ...) { # nocov start
   if (is.array(x) || length(x) > 1L) {
     cat("Units: ", as.character(attr(x, "units")), "\n", sep = "")
-    y <- unclass(x)
-    attr(y, "units") <- NULL
-    print(y)
-  } else { 
-    u = as.character(attr(x, "units"))
-    if (u == "")
-      u = "(Units: 1)"
-    cat(format(unclass(x), digits = digits), " ", u, "\n", sep = "")
+    x <- unclass(x)
+    attr(x, "units") <- NULL
+    NextMethod()
+  } else {
+    cat(format(x, ...), "\n", sep="")
+    invisible(x)
   }
-  invisible(x)
 } # nocov end
-
 
 #' @export
 weighted.mean.units <- function(x, w, ...) 
@@ -76,7 +71,7 @@ quantile.units = function(x, ...) {
 
 #' @export
 format.units = function(x, ...) {
-  paste(format(unclass(x), ...), units(x))
+  paste(NextMethod(), units(x))
 }
 
 #' @export


### PR DESCRIPTION
This is a very straightforward change that doesn't affect `units` at all (the behaviour is exactly the same), but enables integration into `quantities`. If `units` (or `errors`) calls `print` and `format` directly, there's nothing (reasonable) I can do from `quantities` to integrate the output.