### PR TITLE
use NextMethod for concatenation (2)

### DIFF
--- a/R/misc.R
+++ b/R/misc.R
@@ -1,21 +1,28 @@
 #' @export
 c.units <- function(..., recursive = FALSE) {
-  modified <- FALSE
   args <- list(...)
-  u = units(args[[1]])
-  for (i in seq_along(args)[-1]) {
-    if (!inherits(args[[i]], "units"))
-      stop(paste("argument", i, "is not of class units"))
-    if (units(args[[i]]) != u)
-      modified <- TRUE
-    tr = try(units(args[[i]]) <- u)
-    if (class(tr) == "try-error")
-      stop(paste("argument", i, 
-                 "has units that are not convertible to that of the first argument"))
-  }
-  if (modified)
+  u <- units(args[[1]])
+  if (.convert_to_first_arg(args))
     do.call(c, c(args, recursive=recursive))
   else structure(NextMethod(), units = u, class = "units")
+}
+
+.convert_to_first_arg <- function(dots, env.=parent.frame()) {
+  dots <- deparse(substitute(dots))
+  modified <- FALSE
+  u <- units(env.[[dots]][[1]])
+  for (i in seq_along(env.[[dots]])[-1]) {
+    if (!inherits(env.[[dots]][[i]], "units"))
+      stop(paste("argument", i, "is not of class units"))
+    if (units(env.[[dots]][[i]]) == u)
+      next
+    if (!ud.are.convertible(units(env.[[dots]][[i]]), u))
+      stop(paste("argument", i, 
+                 "has units that are not convertible to that of the first argument"))
+    units(env.[[dots]][[i]]) <- u
+    modified <- TRUE
+  }
+  modified
 }
 
 .as.units = function(x, value) {

--- a/R/misc.R
+++ b/R/misc.R
@@ -1,20 +1,21 @@
 #' @export
 c.units <- function(..., recursive = FALSE) {
+  modified <- FALSE
   args <- list(...)
   u = units(args[[1]])
   for (i in seq_along(args)[-1]) {
     if (!inherits(args[[i]], "units"))
       stop(paste("argument", i, "is not of class units"))
+    if (units(args[[i]]) != u)
+      modified <- TRUE
     tr = try(units(args[[i]]) <- u)
     if (class(tr) == "try-error")
       stop(paste("argument", i, 
                  "has units that are not convertible to that of the first argument"))
   }
-  do.call(.c.units, c(args, recursive=recursive))
-}
-
-.c.units <- function(..., recursive) {
-  structure(NextMethod("c"), units = units(list(...)[[1]]), class = "units")
+  if (modified)
+    do.call(c, c(args, recursive=recursive))
+  else structure(NextMethod(), units = u, class = "units")
 }
 
 .as.units = function(x, value) {

--- a/R/summaries.R
+++ b/R/summaries.R
@@ -8,21 +8,11 @@ Summary.units = function(..., na.rm = FALSE) {
   if (!OK)
     stop(paste("Summary operation", .Generic, "not allowed"))
   
-  args = list(...)
-  u = units(args[[1]])
-  if (length(args) > 1) {
-    for (i in 2:length(args)) {
-      if (!inherits(args[[i]], "units"))
-        stop(paste("argument", i, "is not of class units"))
-      if (!ud.are.convertible(units(args[[i]]), u))
-        stop(paste("argument", i, 
-                   "has units that are not convertible to that of the first argument"))
-      args[[i]] = set_units(args[[i]], u, mode = "standard") # convert to first unit
-    }
-  }
-  args = lapply(args, unclass)
-  # as_units(do.call(.Generic, args), u)
-  as_units(do.call(.Generic, c(args, na.rm = na.rm)), u)
+  args <- list(...)
+  u <- units(args[[1]])
+  if (.convert_to_first_arg(args))
+    do.call(.Generic, c(args, na.rm = na.rm))
+  else structure(NextMethod(), units = u, class = "units")
 }
 
 #' @export
@@ -39,30 +29,15 @@ print.units = function (x, ...) { # nocov start
 } # nocov end
 
 #' @export
-weighted.mean.units <- function(x, w, ...) 
-  structure(weighted.mean(unclass(x), w, ...), 
-            units = attr(x, "units"), class = "units")
-
-
-#' @export
 mean.units = function(x, ...) {
-  .as.units(mean(unclass(x), ...), units(x))
+  .as.units(NextMethod(), units(x))
 }
 
 #' @export
-median.units = function(x, na.rm = FALSE, ...) {
-}
+weighted.mean.units = mean.units
 
-median.units <- if (is.na(match("...", names(formals(median))))) {
-    function(x, na.rm = FALSE) {
-  		.as.units(median(unclass(x), na.rm = na.rm), units(x))
-    }
-} else {
-    function(x, na.rm = FALSE, ...) {
-  		.as.units(median(unclass(x), na.rm = na.rm, ...), units(x))
-    }
-}
-
+#' @export
+median.units = mean.units
 
 #' @export
 quantile.units = function(x, ...) {


### PR DESCRIPTION
The previous patch apparently worked, at least for `units` alone, but effectively `NextMethod` wasn't dispatching any method after `c.units`. I still don't understand why, and it may be a bug in R, because the same code has a different behaviour depending on the scope (i.e., whether the methods are defined in the global environment or exported from packages; see [this reprex](https://github.com/Enchufa2/dispatchS3dots) for more details).

However, I managed to circumvent this issue with this patch. It's based on calling `c` once more if any argument was modified (units changed), and finally calling `NextMethod` cleanly. It is not an ideal solution, because this means that, if any unit changes, `c.units` is called _twice_. But AFAIK, it may be the only solution. And if there is a bug in R, then this is the only backwards-compatible solution.