### PR TITLE
fixes for plot and hist

### DIFF
--- a/R/plot.R
+++ b/R/plot.R
@@ -80,7 +80,7 @@ plot.units <- function(x, y, xlab = NULL, ylab = NULL, ...) {
       xlab <- "Index"
 	y <- x
 	x <- seq_along(x)
-    return(NextMethod("plot", x, y, xlab = xlab, ylab = ylab))
+    return(NextMethod())
   } 
   if (is.null(xlab)) {
     xlab <- make_unit_label(xlab0, x)
@@ -88,9 +88,7 @@ plot.units <- function(x, y, xlab = NULL, ylab = NULL, ...) {
   if (is.null(ylab) && inherits(y, "units")) {
     ylab <- make_unit_label(deparse(substitute(y)), y)
   }
-  x <- unclass(x)
-  y <- unclass(y)
-  NextMethod("plot", xlab = xlab, ylab = ylab)
+  NextMethod()
 }
 
 #' histogram for unit objects
@@ -112,5 +110,5 @@ hist.units <- function(x, xlab = NULL, main = paste("Histogram of", xname), ...)
   if (is.null(xlab)) {
     xlab <- make_unit_label(xname, x)
   }
-  NextMethod("hist", xlab = xlab, main = main)
+  NextMethod()
 }


### PR DESCRIPTION
- No need to `unclass` in `plot`.
- `NextMethod` usage was wrong (call not modified).