### PR TITLE
fix sqrt to behave as ^0.5

### DIFF
--- a/R/math.R
+++ b/R/math.R
@@ -17,6 +17,9 @@
 #' cumsum(a)
 #' signif(a, 2)
 Math.units = function(x, ...) {
+  if (.Generic == "sqrt")
+    return(x^0.5)
+  
   OK <- switch(.Generic, "abs" = , "sign" = , "floor" = , "ceiling" = , "log" = ,
                "trunc" = , "round" = , "signif" = , "cumsum" = , 
                "cummax" = , "cummin" = TRUE, FALSE)
@@ -40,7 +43,7 @@ Math.units = function(x, ...) {
     warning(paste("Operation", .Generic, "not meaningful for units"))
     x = unclass(x)
     attr(x, "units") = NULL
-    NextMethod(.Generic)
+    NextMethod()
   } else {
     # nocov start
     # I'm disabling coverage testing for this part because I am not sure
@@ -55,10 +58,10 @@ Math.units = function(x, ...) {
         u = paste0("lb(",units(x),")")
       else
         stop(paste("log with base", dts$base, "not supported"))
-      .as.units(NextMethod(.Generic), units(symbolic_unit(u, check_is_valid = FALSE)))
+      .as.units(NextMethod(), units(symbolic_unit(u, check_is_valid = FALSE)))
       # nocov end
     } else
-      .as.units(NextMethod(.Generic), units(x))
+      .as.units(NextMethod(), units(x))
   }
 }
 

--- a/tests/testthat/test_math.R
+++ b/tests/testthat/test_math.R
@@ -10,6 +10,9 @@ test_that("we can call math functions on units", {
   expect_equal(as.numeric(sign(ux)), sign(x))
   expect_equal(units(sign(ux)), units(ux)) # FIXME: should this have a unit?
   
+  expect_equal(as.numeric(sqrt(ux^2)), sqrt(x^2))
+  expect_error(sqrt(ux), "units not divisible")
+  
   expect_equal(as.numeric(floor(ux)), floor(x))
   expect_equal(units(floor(ux)), units(ux))
   expect_equal(as.numeric(ceiling(ux)), ceiling(x))


### PR DESCRIPTION
It was previously reporting "not meaningful for units", regardless of the units.