### PR TITLE
fix #115: sign drops units

### DIFF
--- a/R/math.R
+++ b/R/math.R
@@ -20,6 +20,9 @@ Math.units = function(x, ...) {
   if (.Generic == "sqrt")
     return(x^0.5)
   
+  if (.Generic == "sign")
+    return(as.numeric(NextMethod()))
+  
   OK <- switch(.Generic, "abs" = , "sign" = , "floor" = , "ceiling" = , "log" = ,
                "trunc" = , "round" = , "signif" = , "cumsum" = , 
                "cummax" = , "cummin" = TRUE, FALSE)
@@ -29,14 +32,14 @@ Math.units = function(x, ...) {
   if (!OK && (units(x) == rad || units(x) == deg)) {
     OK <- switch(.Generic, sin =, cos =, tan =, sinpi =, cospi =, tanpi = TRUE, FALSE)
     if (OK) {
-	  units(x) <- "rad" # convert deg -> rad
-	  x <- set_units(x) # result has unit 1
-	}
+      units(x) <- "rad" # convert deg -> rad
+      x <- set_units(x) # result has unit 1
+    }
   }
   if (!OK && units(x) == unitless) {
     OK <- switch(.Generic, asin =, acos =, atan = TRUE, FALSE)
     if (OK)
-	  units(x) <- "rad" # unit of the answer (also unitless)
+      units(x) <- "rad" # unit of the answer (also unitless)
   }
 
   if (!OK) {

--- a/tests/testthat/test_math.R
+++ b/tests/testthat/test_math.R
@@ -8,7 +8,7 @@ test_that("we can call math functions on units", {
   expect_equal(units(abs(ux)), units(ux))
   
   expect_equal(as.numeric(sign(ux)), sign(x))
-  expect_equal(units(sign(ux)), units(ux)) # FIXME: should this have a unit?
+  expect_true(!inherits(sign(ux), "units"))
   
   expect_equal(as.numeric(sqrt(ux^2)), sqrt(x^2))
   expect_error(sqrt(ux), "units not divisible")


### PR DESCRIPTION
Simple patch that returns ASAP. 

Under this _principle_, this whole `Math.units` can be improved in terms of performance (the same applies to `Ops.units`). I've been tempted, but I love, as you said once, _fancy things_, such as [this](https://github.com/r-quantities/errors/blob/master/R/math.R#L26), and you may not like it. So I leave the _greater good_ for another day, another discussion. :-)