### PR TITLE
unit dropping consistency

### DIFF
--- a/R/conversion.R
+++ b/R/conversion.R
@@ -138,6 +138,7 @@ as_units.symbolic_units <- function(x, value, ...) {
 #' @export
 #' @name as_units
 as_units.default <- function(x, value = unitless, ...) {
+  if (is.null(x)) return(x)
   units(x) <- value
   x
 }

--- a/R/set_units.R
+++ b/R/set_units.R
@@ -37,9 +37,6 @@ set_units.numeric <- function(x, value, ..., mode = units_options("set_units_mod
       stop("The only valid number defining a unit is '1', signifying a unitless unit")
   }
   
-  if (is.null(value))
-    return(drop_units(x))
-  
   units(x) <- as_units(value, ...)
   x
 }

--- a/tests/testthat/test_conversion.R
+++ b/tests/testthat/test_conversion.R
@@ -132,3 +132,7 @@ test_that("we can convert between units that are not simply a scalar from each o
   expect_equal(units(result), unitless)
 })
 
+test_that("a NULL value returns NULL", {
+  expect_null(as_units(NULL))
+})
+


### PR DESCRIPTION
To be able to implement all combinations of units/errors setting/dropping for `quantities`, `set_units` must delegate to `units<-`. And for that, `as_units(NULL)` must return `NULL`, which would be expected I'd say.