### PR TITLE
fix multiplication and division (2)

### DIFF
--- a/R/arith.R
+++ b/R/arith.R
@@ -67,8 +67,7 @@ Ops.units <- function(e1, e2) {
       numerator <- sort(c(ue1$numerator, ue2$denominator))
       denominator <- sort(c(ue1$denominator, ue2$numerator))
     }
-    value <- as.numeric(NextMethod())
-    return(.simplify_units(value, .symbolic_units(numerator, denominator)))
+    return(.simplify_units(NextMethod(), .symbolic_units(numerator, denominator)))
 
   } else if (pw) { # FIXME: I am not sure how to take powers of non-integers yet
 

--- a/R/symbolic_units.R
+++ b/R/symbolic_units.R
@@ -125,6 +125,7 @@ as.character.symbolic_units <- function(x, ...,
   # before removing matching units.
 
   drop_ones = function(u) u[ u != "1" ]
+  class(value) <- "units"
   
   new_numerator <- drop_ones(sym_units$numerator)
   new_denominator <- drop_ones(sym_units$denominator)
@@ -136,7 +137,8 @@ as.character.symbolic_units <- function(x, ...,
       str2 <- new_denominator[j]
 
       if (are_convertible(str1, str2)) {
-        value <- convert(value, str1, str2)
+        attr(value, "units") <- str1
+        units(value) <- str2
         delete_num <- c(delete_num, i)
         new_denominator <- new_denominator[-j]
         break
@@ -147,5 +149,5 @@ as.character.symbolic_units <- function(x, ...,
   if (length(delete_num) > 0)
     new_numerator <- new_numerator[-delete_num]
   
-  as_units(value, .symbolic_units(new_numerator, new_denominator))
+  as_units(drop_units(value), .symbolic_units(new_numerator, new_denominator))
 }


### PR DESCRIPTION
I've just realised that @mailund's PR broke `NextMethod` dispatch by calling `as.numeric(NextMethod())`. In `quantities`, units methods are always called in the first place, because if the operation needs a unit conversion, errors for that conversion must be propagated. Thus, enclosing `NextMethod` in `as.numeric` throws the errors out.

In the same way, we cannot rely on conversions using the C API (i.e., calling `convert`) directly, because errors are not propagated either. All conversions must ~take place at R level~ be wrapped inside a registered method (i.e., `units<-`), to be able to intercept the call and retrieve the conversion applied from `quantities`. See changes in `.simplify_units` for further details.