### PR TITLE
use .as.units instead of structure (closes #111)

### DIFF
--- a/R/make_units.R
+++ b/R/make_units.R
@@ -1,3 +1,9 @@
+.as.units = function(x, value) {
+  class(x) = "units"
+  attr(x, "units") = value
+  x
+}
+
 #' Unit creation
 #'
 #' A number of functions are provided for creating unit objects. 
@@ -314,7 +320,7 @@ as_units.call <- function(x, check_is_valid = TRUE, ...) {
   
   if(missing(x) || identical(x, quote(expr =)) || 
      identical(x, 1) || identical(x, 1L))
-    return(structure(1, units = unitless, class = "units"))
+    return(.as.units(1, unitless))
   
   stopifnot(is.language(x))
   
@@ -343,7 +349,7 @@ See ?as_units for usage examples.")
 "In ", sQuote(deparse(x)), " the numeric multiplier ", sQuote(as.numeric(unit)), " is invalid. 
 Use `install_conversion_constant()` to define a new unit that is a multiple of another unit.")
   
-  structure(1, units = units(unit), class = "units")
+  .as.units(1, units(unit))
 }
 
 
@@ -370,7 +376,7 @@ symbolic_unit <- function(chr, check_is_valid = TRUE) {
       chr <- sym
   }
   
-  structure(1, units = .symbolic_units(chr), class = "units")
+  .as.units(1, .symbolic_units(chr))
 }
 
 

--- a/R/misc.R
+++ b/R/misc.R
@@ -4,32 +4,7 @@ c.units <- function(..., recursive = FALSE) {
   u <- units(args[[1]])
   if (.convert_to_first_arg(args))
     do.call(c, c(args, recursive=recursive))
-  else structure(NextMethod(), units = u, class = "units")
-}
-
-.convert_to_first_arg <- function(dots, env.=parent.frame()) {
-  dots <- deparse(substitute(dots))
-  modified <- FALSE
-  u <- units(env.[[dots]][[1]])
-  for (i in seq_along(env.[[dots]])[-1]) {
-    if (!inherits(env.[[dots]][[i]], "units"))
-      stop(paste("argument", i, "is not of class units"))
-    if (units(env.[[dots]][[i]]) == u)
-      next
-    if (!ud.are.convertible(units(env.[[dots]][[i]]), u))
-      stop(paste("argument", i, 
-                 "has units that are not convertible to that of the first argument"))
-    units(env.[[dots]][[i]]) <- u
-    modified <- TRUE
-  }
-  modified
-}
-
-.as.units = function(x, value) {
-  x = unclass(x)
-  class(x) = "units"
-  attr(x, "units") = value
-  x
+  else .as.units(NextMethod(), u)
 }
 
 #' @export

--- a/R/summaries.R
+++ b/R/summaries.R
@@ -12,7 +12,7 @@ Summary.units = function(..., na.rm = FALSE) {
   u <- units(args[[1]])
   if (.convert_to_first_arg(args))
     do.call(.Generic, c(args, na.rm = na.rm))
-  else structure(NextMethod(), units = u, class = "units")
+  else .as.units(NextMethod(), u)
 }
 
 #' @export


### PR DESCRIPTION
- `.convert_to_first_arg` moved to `conversion.R`
- `.as.units` moved to `make_units.R`
- `structure` calls replaced with `.as.units`