### PR TITLE
revdep quantities

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -4,3 +4,4 @@
 ^appveyor\.yml$
 docs
 README.md
+^quantities$

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,11 @@ addons:
 
 r_github_packages:
   - r-lib/covr@v3.0.1
+  - r-quantities/errors
+
+script:
+  - git clone https://github.com/r-quantities/quantities.git
+  - bash quantities/scripts/check_with_quantities.sh
 
 after_success:
   - Rscript -e 'covr::codecov()'


### PR DESCRIPTION
I've created a script ([here](https://github.com/r-quantities/quantities/blob/master/scripts/check_with_quantities.sh)) to be used by `units` and `errors` (already deployed there) on Travis CI. The idea is to early detect breaking changes, which can be otherwise difficult to solve due to the tight integration of `quantities` with both packages. It builds and checks the package (Travis' default behaviour), and after that, it checks `quantities` too. I've added log folding too for convenience, as Travis does (see [the log](https://travis-ci.org/r-quantities/units/jobs/395518735)).

These minimal changes are needed to use it, as can be seen in the diff:

- Install a Github-fresh copy of the other package (`errors` for `units` and viceversa).
- Clone the `quantities` repo.
- Launch the script.

If you want to disable this and return to the default checks at any time, you only need to comment out the following lines in `.travis.yml`:

```
#script:
#  - git clone https://github.com/r-quantities/quantities.git
#  - bash quantities/scripts/check_with_quantities.sh
```