### PR TITLE
use specified udunits header locations

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -26,9 +26,11 @@ AC_ARG_WITH([udunits2-include],
 		[udunits2_include_path=$withval])
 if test [ -n "$udunits2_include_path" ] ; then
    UD_CPPFLAGS="-I${udunits2_include_path}"
+   CPPFLAGS="$CPPFLAGS $UD_CPPFLAGS"
 else
    if test [ -n "${UDUNITS2_INCLUDE}" ] ; then
       UD_CPPFLAGS="-I${UDUNITS2_INCLUDE}"
+      CPPFLAGS="$CPPFLAGS $UD_CPPFLAGS"
    fi
 fi
 


### PR DESCRIPTION
AC_CHECK_HEADER was not using the specified --with-udunits2-include argument or the UDUNITS2_INCLUDE environment variable.

The CPPFLAGS were never updated, and the UD_CPPFLAGS never used in AC_CHECK_HEADER. This fixes the situation.