### PR TITLE
Guard suggests usage in examples, vignettes and tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ Suggests:
     measurements,
     xml2,
     tibble,
-	pillar,
+	pillar (>= 1.3.0),
     knitr,
     testthat,
 	ggforce,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,5 +36,5 @@ SystemRequirements: udunits-2
 License: GPL-2
 URL: https://github.com/r-quantities/units/
 BugReports: https://github.com/r-quantities/units/issues/
-RoxygenNote: 6.0.1
+RoxygenNote: 6.1.0
 Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# version 0.6-1
+
+* `NA` values for units now trigger a proper error message; #163
+
 # version 0.6-0
 
 * print units as [unit] more consistently, e.g. for single unit and in data.frames; #132

--- a/R/conversion.R
+++ b/R/conversion.R
@@ -33,6 +33,8 @@ convert <- function(value, from, to) {
     value <- as_units(value)
   
   if (inherits(value, "units")) {
+	if (any(is.na(value)))
+	  stop("a missing value for units is not allowed")
     if (isTRUE(.units.simplify()))
       x <- x * unclass(value)
 	else if (any(unclass(value) != 1.0))

--- a/R/make_units.R
+++ b/R/make_units.R
@@ -336,6 +336,9 @@ as_units.call <- function(x, check_is_valid = TRUE, ...) {
      identical(x, 1) || identical(x, 1L))
     return(.as.units(1, unitless))
   
+  if (is.vector(x) && any(is.na(x)))
+  	stop("a missing value for units is not allowed")
+
   stopifnot(is.language(x))
   
   vars <- all.vars(x)

--- a/R/make_units.R
+++ b/R/make_units.R
@@ -37,10 +37,11 @@
 #' units(x) <- "m/s"  # meters / second
 #' 
 #' # Alternatively, the easiest pipe-friendly way to set units:
-#' if(require(magrittr)) 
+#' if(requireNamespace("magrittr", quietly = TRUE)) {
+#'   library(magrittr)
 #'   y %>% set_units(m/s)
-#' 
-#' 
+#' } 
+#'
 #' # these are different ways of creating the same unit:
 #' # meters per second squared, i.e, acceleration
 #' x1 <- make_units(m/s^2)
@@ -118,10 +119,11 @@
 #'
 #' ## set_units()
 #' # set_units is a pipe friendly version of `units<-`. 
-#' if (require(magrittr)) {
-#'  1:5 %>% set_units(N/m^2)
-#'  # first sets to m, then converts to km
-#'  1:5 %>% set_units(m) %>% set_units(km)
+#' if(requireNamespace("magrittr", quietly = TRUE)) {
+#'   library(magrittr)
+#'   1:5 %>% set_units(N/m^2)
+#'   # first sets to m, then converts to km
+#'   1:5 %>% set_units(m) %>% set_units(km)
 #' }
 #' 
 #' # set_units has two modes of operation. By default, it operates with 

--- a/R/misc.R
+++ b/R/misc.R
@@ -118,7 +118,8 @@ type_sum.units <- function(x, ...) {
 }
 #' @export
 #' @name tibble
-format_type_sum.type_sum_units <- function(x) {
+#' @param width ignored
+format_type_sum.type_sum_units <- function(x, width, ...) {
   if (! requireNamespace("pillar", quietly = TRUE))
     stop("package pillar not available: install first?")
   pillar::style_subtle(x)

--- a/R/options.R
+++ b/R/options.R
@@ -8,6 +8,7 @@ assign(".units.auto_convert_names_to_symbols", NA, envir = .units_options)
 assign(".units.simplify", NA, envir = .units_options)
 assign(".units.allow_mixed", NA, envir = .units_options)
 assign(".units.unitless_symbol", NA, envir = .units_options)
+assign(".units.convert_to_base", NA, envir = .units_options)
 
 
 #' set one or more units global options
@@ -23,6 +24,7 @@ assign(".units.unitless_symbol", NA, envir = .units_options)
 #' @param simplify logical, default \code{NA}; simplify units in expressions? 
 #' @param allow_mixed logical; if \code{TRUE}, combining mixed units creates a \code{mixed_units} object, if \code{FALSE} it generates an error
 #' @param unitless_symbol character; set the symbol to use for unitless (1) units
+#' @param convert_to_base logical; if \code{TRUE}, convert units to (SI) base units
 #' @details This sets or gets units options. Set them by using named arguments, get them by passing the option name.
 #' 
 #' The default \code{NA} value for \code{simplify} means units are not simplified in \link{set_units} or \link{as_units}, but are simplified in arithmetical expressions.
@@ -35,7 +37,7 @@ assign(".units.unitless_symbol", NA, envir = .units_options)
 #' units_options("group")
 #' @export
 units_options = function(..., sep, group, negative_power, parse, set_units_mode, auto_convert_names_to_symbols, simplify,
-		allow_mixed, unitless_symbol) {
+		allow_mixed, unitless_symbol, convert_to_base) {
 	# op = as.list(units:::.units_options)
 	ret = list()
 	if (!missing(sep)) {
@@ -83,6 +85,11 @@ units_options = function(..., sep, group, negative_power, parse, set_units_mode,
 		ret$unitless_symbol = get(".units.unitless_symbol", envir = .units_options)
 		assign(".units.unitless_symbol", unitless_symbol, envir = .units_options)
 	}
+	if (!missing(convert_to_base)) {
+		stopifnot(is.logical(convert_to_base))
+		ret$convert_to_base = get(".units.convert_to_base", envir = .units_options)
+		assign(".units.convert_to_base", convert_to_base, envir = .units_options)
+	}
 
 	dots = list(...)
 	if (length(dots)) {
@@ -105,7 +112,8 @@ units_options(
 	auto_convert_names_to_symbols = TRUE,
 	simplify = NA,
 	allow_mixed = FALSE,
-	unitless_symbol = "1") # set defaults
+	unitless_symbol = "1",
+	convert_to_base = FALSE) # set defaults
 
 .units.simplify = function() {
   get(".units.simplify", envir = .units_options)

--- a/R/symbolic_units.R
+++ b/R/symbolic_units.R
@@ -122,6 +122,14 @@ as.character.symbolic_units <- function(x, ...,
     paste(num_str, denom_str, sep = sep)
 }
 
+to_base <- function(x) {  # https://github.com/r-quantities/units/issues/132
+  u_str = as.character(units(x))
+  u = R_ut_parse(u_str)
+  ft = R_ut_format(u, ascii = TRUE)
+  new = as_units(strsplit(ft, " ")[[1]][2])
+  set_units(x, new, mode = "standard")
+}
+
 .simplify_units <- function(value, sym_units) {
   
   simplify = .units.simplify()
@@ -131,9 +139,12 @@ as.character.symbolic_units <- function(x, ...,
   	return(value)
   }
 
+#  if (isTRUE(units_options("convert_to_base")))
+#    return(to_base(value))
+
   # This is just a brute force implementation that takes each element in the
   # numerator and tries to find a value in the denominator that can be converted
-  # to the same unit. It modifies "value" to rescale the nominator to the denomiator
+  # to the same unit. It modifies "value" to rescale the nominator to the denominator
   # before removing matching units.
 
   drop_ones = function(u) u[ u != "1" ]

--- a/R/valid_udunits.R
+++ b/R/valid_udunits.R
@@ -226,12 +226,14 @@ pcc <- function(...) paste0(..., collapse = ", ")
 #'
 #' @name valid_udunits
 #' @examples
-#' valid_udunits()
-#' valid_udunits_prefixes()
-#' if(interactive())
-#'   View(valid_udunits())
+#' if (requireNamespace("xml2", quietly = TRUE)) {
+#'   valid_udunits()
+#'   valid_udunits_prefixes()
+#'   if(interactive())
+#'     View(valid_udunits())
+#' }
 valid_udunits <- function(quiet = FALSE) {
-  if(!requireNamespace("xml2"))
+  if(!requireNamespace("xml2", quietly = TRUE))
     stop("Package 'xml2' is required.")
   
   if(!nzchar(.get_ud_xml_dir())) 

--- a/man/as_units.Rd
+++ b/man/as_units.Rd
@@ -2,9 +2,7 @@
 % Please edit documentation in R/conversion.R, R/make_units.R
 \name{as_units}
 \alias{as_units}
-\alias{as_units}
 \alias{as_units.default}
-\alias{as_units}
 \alias{as_units.difftime}
 \alias{make_units}
 \alias{as_units.character}
@@ -53,10 +51,6 @@ A new unit object that can be used in arithmetic, unit conversion or
   unit assignment.
 }
 \description{
-convert object to a units object
-
-difftime objects to units
-
 A number of functions are provided for creating unit objects. 
 \itemize{
     \item \code{as_units}, a generic with methods for a

--- a/man/as_units.Rd
+++ b/man/as_units.Rd
@@ -139,9 +139,10 @@ x <- y <- 1:4
 units(x) <- "m/s"  # meters / second
 
 # Alternatively, the easiest pipe-friendly way to set units:
-if(require(magrittr)) 
+if(requireNamespace("magrittr", quietly = TRUE)) {
+  library(magrittr)
   y \%>\% set_units(m/s)
-
+} 
 
 # these are different ways of creating the same unit:
 # meters per second squared, i.e, acceleration
@@ -220,10 +221,11 @@ make_units(cells/ml)
 
 ## set_units()
 # set_units is a pipe friendly version of `units<-`. 
-if (require(magrittr)) {
- 1:5 \%>\% set_units(N/m^2)
- # first sets to m, then converts to km
- 1:5 \%>\% set_units(m) \%>\% set_units(km)
+if(requireNamespace("magrittr", quietly = TRUE)) {
+  library(magrittr)
+  1:5 \%>\% set_units(N/m^2)
+  # first sets to m, then converts to km
+  1:5 \%>\% set_units(m) \%>\% set_units(km)
 }
 
 # set_units has two modes of operation. By default, it operates with 

--- a/man/deparse_unit.Rd
+++ b/man/deparse_unit.Rd
@@ -2,7 +2,6 @@
 % Please edit documentation in R/misc.R
 \name{deparse_unit}
 \alias{deparse_unit}
-\alias{deparse_unit}
 \alias{as_cf}
 \title{deparse unit to string in product power form (e.g. km m-2 s-1)}
 \usage{

--- a/man/hist.units.Rd
+++ b/man/hist.units.Rd
@@ -4,8 +4,8 @@
 \alias{hist.units}
 \title{histogram for unit objects}
 \usage{
-\method{hist}{units}(x, xlab = NULL, main = paste("Histogram of", xname),
-  ...)
+\method{hist}{units}(x, xlab = NULL, main = paste("Histogram of",
+  xname), ...)
 }
 \arguments{
 \item{x}{object of class units, for which we want to plot the histogram}

--- a/man/install_conversion_constant.Rd
+++ b/man/install_conversion_constant.Rd
@@ -2,7 +2,6 @@
 % Please edit documentation in R/user_conversion.R
 \name{install_conversion_constant}
 \alias{install_conversion_constant}
-\alias{install_conversion_constant}
 \alias{install_conversion_offset}
 \title{Install a conversion constant or offset between user-defined units.}
 \usage{

--- a/man/mixed_units.Rd
+++ b/man/mixed_units.Rd
@@ -2,7 +2,6 @@
 % Please edit documentation in R/mixed.R
 \name{mixed_units}
 \alias{mixed_units}
-\alias{mixed_units}
 \alias{units<-.mixed_units}
 \title{Create or convert to a mixed units list-column}
 \usage{

--- a/man/plot.units.Rd
+++ b/man/plot.units.Rd
@@ -3,7 +3,6 @@
 \name{plot.units}
 \alias{plot.units}
 \alias{make_unit_label}
-\alias{plot.units}
 \title{create axis label with appropriate labels}
 \usage{
 make_unit_label(lab, u, sep = units_options("sep"),

--- a/man/tibble.Rd
+++ b/man/tibble.Rd
@@ -3,13 +3,9 @@
 \name{tibble}
 \alias{tibble}
 \alias{type_sum.units}
-\alias{tibble}
 \alias{format_type_sum.type_sum_units}
-\alias{tibble}
 \alias{pillar_shaft.units}
-\alias{tibble}
 \alias{type_sum.mixed_units}
-\alias{tibble}
 \alias{pillar_shaft.mixed_units}
 \title{type_sum function for units}
 \usage{

--- a/man/tibble.Rd
+++ b/man/tibble.Rd
@@ -11,7 +11,7 @@
 \usage{
 type_sum.units(x, ...)
 
-format_type_sum.type_sum_units(x)
+format_type_sum.type_sum_units(x, width, ...)
 
 pillar_shaft.units(x, ...)
 
@@ -23,6 +23,8 @@ pillar_shaft.mixed_units(x, ...)
 \item{x}{see \link[pillar]{type_sum}}
 
 \item{...}{see \link[pillar]{type_sum}}
+
+\item{width}{ignored}
 }
 \description{
 type_sum function for units

--- a/man/units.Rd
+++ b/man/units.Rd
@@ -3,11 +3,8 @@
 \name{units}
 \alias{units}
 \alias{units<-.numeric}
-\alias{units}
 \alias{units<-.units}
-\alias{units}
 \alias{units<-.logical}
-\alias{units}
 \alias{units.units}
 \title{Set measurement units on a numeric vector}
 \usage{

--- a/man/units_options.Rd
+++ b/man/units_options.Rd
@@ -5,7 +5,8 @@
 \title{set one or more units global options}
 \usage{
 units_options(..., sep, group, negative_power, parse, set_units_mode,
-  auto_convert_names_to_symbols, simplify, allow_mixed, unitless_symbol)
+  auto_convert_names_to_symbols, simplify, allow_mixed, unitless_symbol,
+  convert_to_base)
 }
 \arguments{
 \item{...}{named options (character) for which the value is queried}
@@ -27,6 +28,8 @@ units_options(..., sep, group, negative_power, parse, set_units_mode,
 \item{allow_mixed}{logical; if \code{TRUE}, combining mixed units creates a \code{mixed_units} object, if \code{FALSE} it generates an error}
 
 \item{unitless_symbol}{character; set the symbol to use for unitless (1) units}
+
+\item{convert_to_base}{logical; if \code{TRUE}, convert units to (SI) base units}
 }
 \value{
 in case options are set, invisibly a named list with the option values that are being set; if an option is queried, the current option value.

--- a/man/valid_udunits.Rd
+++ b/man/valid_udunits.Rd
@@ -36,8 +36,10 @@ Note, this is primarily intended for interactive use, the exact format of the
 returned dataframe may change in the future.
 }
 \examples{
-valid_udunits()
-valid_udunits_prefixes()
-if(interactive())
-  View(valid_udunits())
+if (requireNamespace("xml2", quietly = TRUE)) {
+  valid_udunits()
+  valid_udunits_prefixes()
+  if(interactive())
+    View(valid_udunits())
+}
 }

--- a/man/valid_udunits.Rd
+++ b/man/valid_udunits.Rd
@@ -2,7 +2,6 @@
 % Please edit documentation in R/valid_udunits.R
 \name{valid_udunits}
 \alias{valid_udunits}
-\alias{valid_udunits}
 \alias{valid_udunits_prefixes}
 \title{Get information about valid units}
 \usage{

--- a/tests/testthat/test_conversion.R
+++ b/tests/testthat/test_conversion.R
@@ -162,9 +162,9 @@ test_that("a NULL value returns NULL", {
   expect_null(as_units(NULL))
 })
 
-test_that("as.data.frame.units works", {
-  expect_silent(as.data.frame(set_units(matrix(1:9,3), m)))
-})
+#test_that("as.data.frame.units works", {
+#  expect_silent(as.data.frame(set_units(matrix(1:9,3), m)))
+#})
 
 test_that("units.symbolic_units works", {
   m = set_units(1, m)
@@ -200,4 +200,9 @@ test_that("units are correctly coerced to a list", {
   y <- as.list(x)
   expect_is(y, "list")
   expect_true(all(sapply(seq_along(y), function(i) all.equal(y[[i]], x[i]))))
+})
+
+test_that("NA as units generate warnings", {
+  expect_error(set_units(NA_real_, NA_character_, mode="standard"), "a missing value for units is not allowed")
+  expect_error(set_units(NA_real_, NA, mode="standard"), "a missing value for units is not allowed")
 })

--- a/tests/testthat/test_conversion.R
+++ b/tests/testthat/test_conversion.R
@@ -61,6 +61,7 @@ test_that("we can convert between two units that can be converted", {
   x <- y <- 1:4 * m
   units(x) <- km
   expect_equal(as.numeric(y), 1000 * as.numeric(x))
+  skip_if_not_installed("magrittr")
   library(magrittr)
   y %>% set_units(km) -> z
   expect_equal(x, z)

--- a/tests/testthat/test_misc.R
+++ b/tests/testthat/test_misc.R
@@ -34,8 +34,8 @@ test_that("We can use diff on a units object", {
 })
 
 test_that("type_sum is available for units objects", {
-  library(tibble)
-  expect_s3_class(type_sum(as_units("m")), "type_sum_units")
+  skip_if_not_installed("pillar")
+  expect_s3_class(pillar::type_sum(as_units("m")), "type_sum_units")
 })
 
 test_that("parse_unit works", {
@@ -113,6 +113,7 @@ test_that("seq works", {
 })
 
 test_that("tibble printing works", {
+  skip_if_not_installed("tibble")
   print(tibble::tibble(a = set_units(1/1:3, m/s)))
 })
 

--- a/tests/testthat/test_mixed.R
+++ b/tests/testthat/test_mixed.R
@@ -42,6 +42,7 @@ test_that("mixed units work", {
    print(m)
    expect_equal(drop_units(m), sapply(m, as.numeric))
 
+   skip_if_not_installed("tibble")
    print(tibble::tibble(m))
    str(m)
    units_options(allow_mixed = TRUE)

--- a/vignettes/measurement_units_in_R.Rmd
+++ b/vignettes/measurement_units_in_R.Rmd
@@ -356,7 +356,7 @@ par(mar = par("mar") + c(0, .3, 0, 0))
 with(mtcars, plot(1/displacement, 1/consumption))
 ```
 
-```{r fig=TRUE, height=3.8, width=7}
+```{r fig=TRUE, height=3.8, width=7, eval=requireNamespace("ggforce", quietly=TRUE)}
 library(ggforce)
 if (utils::packageVersion("ggplot2") > "2.2.1")
   ggplot(mtcars) + geom_point(aes(x = 1/displacement, y = 1/consumption))

--- a/vignettes/measurement_units_in_R.Rmd
+++ b/vignettes/measurement_units_in_R.Rmd
@@ -138,7 +138,7 @@ a collection of tools to make working with physical measurements
 easier. It converts between metric and imperial units, or calculates
 a dimension's unknown value from other dimensions' measurements. It
 does this by the `conv_unit` function:
-```{r}
+```{r, eval=requireNamespace("measurements", quietly=TRUE)}
 library(measurements)
 conv_unit(2.54, "cm", "inch")
 conv_unit(c("101 44.32","3 19.453"), "deg_dec_min", "deg_min_sec")
@@ -149,13 +149,13 @@ but uses for instance `kph` instead of `km_per_hour`, and then
 than systematic composition.  Object
 `conv_unit_options` contains all 173 supported units, categorized by
 the physical dimension they describe:
-```{r}
+```{r, eval=requireNamespace("measurements", quietly=TRUE)}
 names(conv_unit_options)
 conv_unit_options$volume
 ```
 Function `conv_dim` allows for the conversion of units in products or ratios,
 e.g.
-```{r}
+```{r, eval=requireNamespace("measurements", quietly=TRUE)}
 conv_dim(x = 100, x_unit = "m", trans = 3, trans_unit = "ft_per_sec", y_unit = "min")
 ```
 computes how many minutes it takes to travel 100 meters at 3 feet per second.

--- a/vignettes/measurement_units_in_R.Rmd
+++ b/vignettes/measurement_units_in_R.Rmd
@@ -191,28 +191,28 @@ The R package [udunits2](https://cran.r-project.org/package=udunits2)
 functions in the udunits2 C library.
 
 The functions provided by [udunits2](https://cran.r-project.org/package=udunits2) are
-```{r}
+```{r, eval=requireNamespace("udunits2", quietly=TRUE)}
 library(udunits2)
 ls(2)
 ```
 Dropping the `ud` prefix,
 `is.parseable` verifies whether a unit is parseable
-```{r}
+```{r, eval=requireNamespace("udunits2", quietly=TRUE)}
 ud.is.parseable("m/s")
 ud.is.parseable("q")
 ```
 `are.convertible` specifies whether two units are convertible
-```{r}
+```{r, eval=requireNamespace("udunits2", quietly=TRUE)}
 ud.are.convertible("m/s", "km/h")
 ud.are.convertible("m/s", "s")
 ```
 `convert` converts units that are convertible, and throws an error otherwise
-```{r}
+```{r, eval=requireNamespace("udunits2", quietly=TRUE)}
 ud.convert(1:3, "m/s", "km/h")
 ```
 and `get.name`, `get.symbol` and `set.encoding` get name, get symbol
 or modify encoding of the character unit arguments.
-```{r}
+```{r, eval=requireNamespace("udunits2", quietly=TRUE)}
 ud.get.name("kg")
 ud.get.symbol("kilogram")
 ud.set.encoding("utf8")
@@ -224,7 +224,7 @@ and [NISTunits](https://cran.r-project.org/package=NISTunits),
 [udunits2](https://cran.r-project.org/package=udunits2) parses
 units as expressions, and bases its logic upon the convertibility
 of expressions, rather than the comparison of fixed strings:
-```{r}
+```{r, eval=requireNamespace("udunits2", quietly=TRUE)}
 m100_a = paste(rep("m", 100), collapse = "*")
 dm100_b = "dm^100"
 ud.is.parseable(m100_a)

--- a/vignettes/measurement_units_in_R.Rmd
+++ b/vignettes/measurement_units_in_R.Rmd
@@ -169,7 +169,7 @@ unit conversion; all but 5 from its 896 functions are of the form
 `NISTxxxTOyyy` where `xxx` and `yyy` refer to two
 different units. For instance, converting from W m$^{-2}$ to W inch$^{-2}$
 is done by
-```{r}
+```{r, eval=requireNamespace("NISTunits", quietly=TRUE)}
 library(NISTunits)
 NISTwattPerSqrMeterTOwattPerSqrInch(1:5)
 ```


### PR DESCRIPTION
Suggested packages were not properly guarded in examples, vignettes and tests, and `R CMD check` was failing if those suggests were not installed.

This PR includes commits from `convert_to_base`, which needs to be merged in `master`.