### PR TITLE
close #168: set minimum Rcpp version required

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,7 @@ Depends:
 Imports:
 	Rcpp
 LinkingTo:
-	Rcpp
+	Rcpp (>= 0.12.10)
 Suggests:
 	udunits2,
     NISTunits,


### PR DESCRIPTION
The template argument missing in #168 was added [in release 0.12.10](https://github.com/RcppCore/Rcpp/commit/e3799de10288b0bbbdb663ec2b8f5073f4542889#diff-02f0b547c2779d25cff89672135f20e3).