### PR TITLE
close #192: fix valgrind issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
       - libudunits2-dev
 
 r_github_packages:
-  - r-lib/covr@v3.0.1
+  - r-lib/covr
   - r-quantities/errors
 
 script:

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * don't force `as.numeric` when unnecessary; #182 addressing #181
 
+* fix valgrind issues on CRAN and tidy up tests; #193 addressing #192
+
 # version 0.6-2
 
 * fix support for logarithms and decibels; #177 addressing #176

--- a/R/init.R
+++ b/R/init.R
@@ -22,6 +22,6 @@ NULL
     packageStartupMessage(msg)
 }
 
-.onUnLoad = function(libname, pkgname) {
+.onUnload = function(libname, pkgname) {
 	udunits_exit()
 }

--- a/src/io.c
+++ b/src/io.c
@@ -1,3 +1,4 @@
+#include <R.h>
 #include <udunits2.h>
 #include "io.h"
 

--- a/src/io.c
+++ b/src/io.c
@@ -1,7 +1,4 @@
-#include <R.h>
 #include <udunits2.h>
-#include <stdio.h> /* FILENAME_MAX */
-
 #include "io.h"
 
 /* From the enum comments in udunits2.h */

--- a/src/io.h
+++ b/src/io.h
@@ -1,2 +1,4 @@
+#include <R.h>
+
 void r_error_fn(const char* fmt, va_list args);
 void handle_error(const char *calling_function);

--- a/src/io.h
+++ b/src/io.h
@@ -1,4 +1,2 @@
-#include <R.h>
-
 void r_error_fn(const char* fmt, va_list args);
 void handle_error(const char *calling_function);

--- a/src/udunits.cpp
+++ b/src/udunits.cpp
@@ -10,9 +10,9 @@
 
 extern "C" {
 #include "io.h"
+#include <udunits2.h>
 }
 
-#include <udunits2.h>
 #include <Rcpp.h>
 
 using namespace Rcpp;

--- a/src/udunits.cpp
+++ b/src/udunits.cpp
@@ -8,20 +8,18 @@
   Functions to support the R interface to the udunits (API version 2) library
 */
 
-#include "Rcpp.h"
+extern "C" {
+#include "io.h"
+}
+
+#include <udunits2.h>
+#include <Rcpp.h>
 
 using namespace Rcpp;
-
-extern "C" {
-#include <R.h>
-#include <udunits2.h>
-#include "units.h"
+typedef XPtr<ut_unit, PreserveStorage, ut_free, true> XPtrUT;
 
 ut_system *sys = NULL;
 static ut_encoding enc = UT_UTF8;
-
-#include "io.h"
-}
 
 // [[Rcpp::export]]
 void udunits_init(CharacterVector path) {
@@ -43,14 +41,6 @@ void udunits_exit() {  // #nocov start
   ut_free_system(sys);
   sys = NULL;
 }                      // #nocov end
-
-// typedef std::vector<void *> ut_vec;
-
-void finalizeUT(ut_unit *ptr) {
-  ut_free(ptr);
-}
-
-// typedef XPtr<ut_unit,PreserveStorage,finalizeUT> XPtrUT;
 
 // wrap a ut_unit pointer in an XPtr
 XPtrUT ut_wrap(ut_unit *u) {

--- a/src/udunits.cpp
+++ b/src/udunits.cpp
@@ -8,12 +8,12 @@
   Functions to support the R interface to the udunits (API version 2) library
 */
 
+#include <Rcpp.h>
+#include <udunits2.h>
+
 extern "C" {
 #include "io.h"
-#include <udunits2.h>
 }
-
-#include <Rcpp.h>
 
 using namespace Rcpp;
 typedef XPtr<ut_unit, PreserveStorage, ut_free, true> XPtrUT;

--- a/src/units.h
+++ b/src/units.h
@@ -1,7 +1,0 @@
-#include <udunits2.h>
-#include "Rcpp.h"
-
-using namespace Rcpp;
-
-void finalizeUT(ut_unit *ptr);
-typedef XPtr<ut_unit,PreserveStorage,finalizeUT,true> XPtrUT;

--- a/tests/plot.R
+++ b/tests/plot.R
@@ -28,5 +28,4 @@ plot(u, type = 'l')
 hist(u)
 boxplot(u)
 
-units_options(sep = c("~~~", "~"), group = c("", "")) # more space, no brackets
-units_options(sep = c("~", "~"), group = c("[", "]"), negative_power = FALSE, parse = TRUE)
+do.call(units_options, units:::.default_options)

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -2,3 +2,4 @@ library(testthat)
 library(units)
 
 test_check("units")
+do.call(units_options, units:::.default_options)

--- a/tests/testthat/test_conversion.R
+++ b/tests/testthat/test_conversion.R
@@ -175,6 +175,9 @@ test_that("new base units work", {
   install_symbolic_unit("person", dimensionless = FALSE)
   expect_equal(set_units(1, person) + set_units(1, kperson), set_units(1001, person))
   expect_error(set_units(1, person) + set_units(1, rad), "cannot convert")
+  
+  # restore
+  remove_symbolic_unit("person")
 })
 
 test_that("errors are correctly coerced to a data frame", {

--- a/tests/testthat/test_conversion.R
+++ b/tests/testthat/test_conversion.R
@@ -2,9 +2,9 @@ context("Unit conversion")
 
 test_that("we can convert numbers to unit-less units", {
   x <- as_units(1:4)
-  expect_that(length(x), equals(4))
-  expect_that(class(x), equals("units"))
-  expect_that(as.numeric(x), equals(1:4))
+  expect_equal(length(x), 4)
+  expect_equal(class(x), "units")
+  expect_equal(as.numeric(x), 1:4)
   
   y <- 1:4
   units(y) <- unitless
@@ -14,9 +14,9 @@ test_that("we can convert numbers to unit-less units", {
 test_that("we can convert numbers to physical units", {
   m <- as_units("m")
   x <- 1:4 * m
-  expect_that(length(x), equals(4))
-  expect_that(class(x), equals("units"))
-  expect_that(as.character(units(x)), equals("m"))
+  expect_equal(length(x), 4)
+  expect_equal(class(x), "units")
+  expect_equal(as.character(units(x)), "m")
   expect_equal(as.numeric(x), 1:4)
   
   y <- 1:4
@@ -24,9 +24,9 @@ test_that("we can convert numbers to physical units", {
   expect_equal(x, y)
   
   z <- 1:4 / m
-  expect_that(length(z), equals(4))
-  expect_that(class(z), equals("units"))
-  expect_that(as.character(units(z)), equals("1/m"))
+  expect_equal(length(z), 4)
+  expect_equal(class(z), "units")
+  expect_equal(as.character(units(z)), "1/m")
   expect_equal(as.numeric(z), 1:4)
 })
 
@@ -44,7 +44,7 @@ test_that("we can convert NA values to physical units", {
 
   x <- NA
   units(x) <- m
-  expect_that(as.character(units(x)), equals('m'))
+  expect_equal(as.character(units(x)), 'm')
 
   x <- rep(NA,5)
   s <- as_units("s")

--- a/tests/testthat/test_misc.R
+++ b/tests/testthat/test_misc.R
@@ -121,11 +121,6 @@ test_that("str works", {
   str(set_units(1/1:3, m/s))
 })
 
-test_that("onload/unload work", {
-  units:::.onUnLoad()
-  units:::.onLoad()
-})
-
 test_that("deprecations work", {
   expect_warning(parse_unit("m"))
 })

--- a/tests/testthat/test_mixed.R
+++ b/tests/testthat/test_mixed.R
@@ -29,16 +29,16 @@ test_that("mixed units work", {
    expect_s3_class(m[1:3] / mixed_units(set_units(1, mm)), "mixed_units")
    expect_s3_class(m[1:3] + mixed_units(set_units(1, mm)), "mixed_units")
    expect_s3_class(m[1:3] - mixed_units(set_units(1, mm)), "mixed_units")
-   expect_that(m[1:3] == mixed_units(set_units(1, mm)), is.logical)
-   expect_that(m[1:3] != mixed_units(set_units(1, mm)), is.logical)
+   expect_is(m[1:3] == mixed_units(set_units(1, mm)), "logical")
+   expect_is(m[1:3] != mixed_units(set_units(1, mm)), "logical")
    expect_error(m[1:3] ^ mixed_units(set_units(1, mm)))
 
 # this breaks -- seems to be an s3 limitation:
    expect_error(m[1:3] * set_units(1, mm))
 
    expect_s3_class(units(m), "mixed_symbolic_units")
-   expect_that(format(m), is.character)
-   expect_that(as.character(units(m)), is.character)
+   expect_is(format(m), "character")
+   expect_is(as.character(units(m)), "character")
    print(m)
    expect_equal(drop_units(m), sapply(m, as.numeric))
 

--- a/tests/testthat/test_udunits.R
+++ b/tests/testthat/test_udunits.R
@@ -10,8 +10,9 @@ test_that("udunits low-level functions work", {
   b <- units:::R_ut_parse("g")
   expect_error(units:::R_convert_doubles(a, b, 1:10), "not convertible")
 
-  u = units:::R_ut_offset("kg", "g10", 10)
-  expect_equal(set_units(set_units(1, kg), g10), set_units(11, g10))
+  u = units:::R_ut_offset("foo", "kg", -10)
+  expect_equal(set_units(set_units(1, kg), foo), set_units(11, foo))
+  remove_symbolic_unit("foo")
 
   expect_silent(units:::R_ut_divide(a, b))
   expect_silent(units:::R_ut_multiply(a, b))

--- a/tests/testthat/test_user_conversion.R
+++ b/tests/testthat/test_user_conversion.R
@@ -33,15 +33,26 @@ test_that("we can convert between units with a user-defined function", {
   install_symbolic_unit("aaa")
   install_conversion_offset("aaa", "bbb", 2) # bbb is aaa + 2
   expect_warning(install_symbolic_unit("aaa"), "is already a valid unit")
+  
+  # restore
+  remove_symbolic_unit("orange")
+  remove_symbolic_unit("apple")
+  remove_symbolic_unit("banana")
+  remove_symbolic_unit("aaa")
+  remove_symbolic_unit("bbb")
 })
 
 test_that("we can simplify via user-defined units", {
-  remove_symbolic_unit("apple")
+  install_symbolic_unit("orange")
   install_conversion_constant("orange", "apple", 2) # one orange is worth two apples
   apples <- 4 * as_units("apple")
   oranges <- 2 * as_units("orange")
   expect_equal(apples / oranges, set_units(1))
   expect_equal(oranges / apples, set_units(1))
+  
+  # restore
+  remove_symbolic_unit("orange")
+  remove_symbolic_unit("apple")
 })
 
 test_that("removing units works", {
@@ -49,5 +60,4 @@ test_that("removing units works", {
   expect_silent(install_symbolic_unit("foo"))
   expect_silent(remove_symbolic_unit("foo"))
   expect_error(remove_symbolic_unit("foo"))
-  expect_silent(remove_symbolic_unit("g")) # removes symbol
 })


### PR DESCRIPTION
- Avoid loading/unloading the package during tests ([that's a problem](http://r.789695.n4.nabble.com/SIGSEGV-in-R-RunWeakRefFinalizer-object-allocated-with-Rcpp-td4751510.html)) to fix valgrind issues. Otherwise, some weak ref finalizers may run after the unit system has been freed.
- Tidy up tests to ensure that options and units are restored.