### PR TITLE
Force units' finalizers before freeing the system

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ r:
   - devel
   #- oldrel
 
+warnings_are_errors: true
+
 addons:
   apt:
     packages:

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -26,11 +26,11 @@ R_convert_doubles <- function(from, to, val) {
 }
 
 R_ut_new_dimensionless_unit <- function(name) {
-    .Call('_units_R_ut_new_dimensionless_unit', PACKAGE = 'units', name)
+    invisible(.Call('_units_R_ut_new_dimensionless_unit', PACKAGE = 'units', name))
 }
 
 R_ut_new_base_unit <- function(name) {
-    .Call('_units_R_ut_new_base_unit', PACKAGE = 'units', name)
+    invisible(.Call('_units_R_ut_new_base_unit', PACKAGE = 'units', name))
 }
 
 R_ut_remove_unit <- function(name) {
@@ -38,11 +38,11 @@ R_ut_remove_unit <- function(name) {
 }
 
 R_ut_scale <- function(nw, old, d) {
-    .Call('_units_R_ut_scale', PACKAGE = 'units', nw, old, d)
+    invisible(.Call('_units_R_ut_scale', PACKAGE = 'units', nw, old, d))
 }
 
 R_ut_offset <- function(nw, old, d) {
-    .Call('_units_R_ut_offset', PACKAGE = 'units', nw, old, d)
+    invisible(.Call('_units_R_ut_offset', PACKAGE = 'units', nw, old, d))
 }
 
 R_ut_divide <- function(numer, denom) {

--- a/R/init.R
+++ b/R/init.R
@@ -23,5 +23,7 @@ NULL
 }
 
 .onUnload = function(libname, pkgname) {
+  # force run weak finalizers before freeing sys
+  invisible(gc())
 	udunits_exit()
 }

--- a/R/user_conversion.R
+++ b/R/user_conversion.R
@@ -24,9 +24,9 @@ install_symbolic_unit <- function(name, warn = TRUE, dimensionless = TRUE) {
     remove_symbolic_unit(name)
   }
   if (dimensionless)
-  	invisible(R_ut_new_dimensionless_unit(name))
+  	R_ut_new_dimensionless_unit(name)
   else
-  	invisible(R_ut_new_base_unit(name))
+  	R_ut_new_base_unit(name)
 }
 
 #' @export
@@ -68,9 +68,9 @@ install_conversion_constant <- function(from, to, const) {
   if (! xor(ud_is_parseable(from), ud_is_parseable(to)))
     stop("exactly one of (from, to) must be a known unit")
   if (ud_is_parseable(to))
-  	invisible(R_ut_scale(as.character(from), as.character(to), as.double(const)))
+  	R_ut_scale(as.character(from), as.character(to), as.double(const))
   else
-    invisible(R_ut_scale(as.character(to), as.character(from), 1.0 / as.double(const)))
+    R_ut_scale(as.character(to), as.character(from), 1.0 / as.double(const))
 }
 
 #' @export
@@ -86,7 +86,7 @@ install_conversion_offset <- function(from, to, const) {
   if (! xor(ud_is_parseable(from), ud_is_parseable(to)))
     stop("exactly one of (from, to) must be a known unit")
   if (ud_is_parseable(to))
-    invisible(R_ut_offset(as.character(from), as.character(to), -as.double(const)))
+    R_ut_offset(as.character(from), as.character(to), -as.double(const))
   else
-    invisible(R_ut_offset(as.character(to), as.character(from), as.double(const)))
+    R_ut_offset(as.character(to), as.character(from), as.double(const))
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -72,25 +72,23 @@ BEGIN_RCPP
 END_RCPP
 }
 // R_ut_new_dimensionless_unit
-SEXP R_ut_new_dimensionless_unit(CharacterVector name);
+void R_ut_new_dimensionless_unit(CharacterVector name);
 RcppExport SEXP _units_R_ut_new_dimensionless_unit(SEXP nameSEXP) {
 BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< CharacterVector >::type name(nameSEXP);
-    rcpp_result_gen = Rcpp::wrap(R_ut_new_dimensionless_unit(name));
-    return rcpp_result_gen;
+    R_ut_new_dimensionless_unit(name);
+    return R_NilValue;
 END_RCPP
 }
 // R_ut_new_base_unit
-SEXP R_ut_new_base_unit(CharacterVector name);
+void R_ut_new_base_unit(CharacterVector name);
 RcppExport SEXP _units_R_ut_new_base_unit(SEXP nameSEXP) {
 BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< CharacterVector >::type name(nameSEXP);
-    rcpp_result_gen = Rcpp::wrap(R_ut_new_base_unit(name));
-    return rcpp_result_gen;
+    R_ut_new_base_unit(name);
+    return R_NilValue;
 END_RCPP
 }
 // R_ut_remove_unit
@@ -104,29 +102,27 @@ BEGIN_RCPP
 END_RCPP
 }
 // R_ut_scale
-SEXP R_ut_scale(CharacterVector nw, CharacterVector old, NumericVector d);
+void R_ut_scale(CharacterVector nw, CharacterVector old, NumericVector d);
 RcppExport SEXP _units_R_ut_scale(SEXP nwSEXP, SEXP oldSEXP, SEXP dSEXP) {
 BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< CharacterVector >::type nw(nwSEXP);
     Rcpp::traits::input_parameter< CharacterVector >::type old(oldSEXP);
     Rcpp::traits::input_parameter< NumericVector >::type d(dSEXP);
-    rcpp_result_gen = Rcpp::wrap(R_ut_scale(nw, old, d));
-    return rcpp_result_gen;
+    R_ut_scale(nw, old, d);
+    return R_NilValue;
 END_RCPP
 }
 // R_ut_offset
-SEXP R_ut_offset(CharacterVector nw, CharacterVector old, NumericVector d);
+void R_ut_offset(CharacterVector nw, CharacterVector old, NumericVector d);
 RcppExport SEXP _units_R_ut_offset(SEXP nwSEXP, SEXP oldSEXP, SEXP dSEXP) {
 BEGIN_RCPP
-    Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< CharacterVector >::type nw(nwSEXP);
     Rcpp::traits::input_parameter< CharacterVector >::type old(oldSEXP);
     Rcpp::traits::input_parameter< NumericVector >::type d(dSEXP);
-    rcpp_result_gen = Rcpp::wrap(R_ut_offset(nw, old, d));
-    return rcpp_result_gen;
+    R_ut_offset(nw, old, d);
+    return R_NilValue;
 END_RCPP
 }
 // R_ut_divide

--- a/src/udunits.cpp
+++ b/src/udunits.cpp
@@ -23,7 +23,7 @@ extern "C" {
 using namespace Rcpp;
 typedef XPtr<ut_unit, PreserveStorage, ut_free, true> XPtrUT;
 
-ut_system *sys = NULL;
+static ut_system *sys = NULL;
 static ut_encoding enc = UT_UTF8;
 
 // [[Rcpp::export]]
@@ -101,19 +101,19 @@ NumericVector R_convert_doubles(SEXP from, SEXP to, NumericVector val) {
 }
 
 // [[Rcpp::export]]
-SEXP R_ut_new_dimensionless_unit(CharacterVector name) {
+void R_ut_new_dimensionless_unit(CharacterVector name) {
   ut_unit *u = ut_new_dimensionless_unit(sys); 
   if (ut_map_name_to_unit(name[0], enc, u) != UT_SUCCESS)
     handle_error("R_ut_new_dimensionless_unit"); // #nocov
-  return ut_wrap(u);
+  ut_free(u);
 }
 
 // [[Rcpp::export]]
-SEXP R_ut_new_base_unit(CharacterVector name) {
+void R_ut_new_base_unit(CharacterVector name) {
   ut_unit *u = ut_new_base_unit(sys); 
   if (ut_map_name_to_unit(name[0], enc, u) != UT_SUCCESS)
     handle_error("R_ut_new_base_unit"); // #nocov
-  return ut_wrap(u);
+  ut_free(u);
 }
 
 // [[Rcpp::export]]
@@ -133,27 +133,27 @@ void R_ut_remove_unit(CharacterVector name) {
 }
 
 // [[Rcpp::export]]
-SEXP R_ut_scale(CharacterVector nw, CharacterVector old, NumericVector d) {
+void R_ut_scale(CharacterVector nw, CharacterVector old, NumericVector d) {
   if (d.size() != 1)
     stop("d should have size 1"); // #nocov
   ut_unit *u_old = ut_parse(sys, ut_trim(old[0], enc), enc);
   ut_unit *u_new = ut_scale(d[0], u_old);
   if (ut_map_name_to_unit(nw[0], enc, u_new) != UT_SUCCESS)
     handle_error("R_ut_scale"); // #nocov
+  ut_free(u_new);
   ut_free(u_old);
-  return ut_wrap(u_new);
 }
 
 // [[Rcpp::export]]
-SEXP R_ut_offset(CharacterVector nw, CharacterVector old, NumericVector d) {
+void R_ut_offset(CharacterVector nw, CharacterVector old, NumericVector d) {
   if (d.size() != 1)
     stop("d should have size 1"); // #nocov
   ut_unit *u_old = ut_parse(sys, ut_trim(old[0], enc), enc);
   ut_unit *u_new = ut_offset(u_old, d[0]);
   if (ut_map_name_to_unit(nw[0], enc, u_new) != UT_SUCCESS)
     handle_error("R_ut_offset"); // #nocov
+  ut_free(u_new);
   ut_free(u_old);
-  return ut_wrap(u_new);
 }
 
 // [[Rcpp::export]]


### PR DESCRIPTION
[This](https://github.com/r-quantities/units/compare/unload?expand=1#diff-2711d8988b4edf6562a0668d7e873c13R27) trick is not very elegant, but it's actually needed. The thing is, each time a unit is wrapped into an Rcpp XPtr, a weak finalizer is registered (which calls to `ut_free` eventually). This is a problem, because we can't control when they are executed. As a result, the package cannot be unloaded cleanly, because there's [a segfault](https://travis-ci.org/r-quantities/units/jobs/504166374#L1376) (builds succeeded because we hadn't [warnings_are_errors](https://github.com/r-quantities/units/compare/unload?expand=1#diff-354f30a63fb0907d4ad57269548329e3R9) set). The segfault happened because 1) `ut_free_system` was called upon unloading, and then 2) `ut_free` was called randomly in a weak finalizer. This call to `gc()` forces the execution of those pending finalizers before freeing the unit system.

And you'd be wondering why we didn't see this until now. The answer is that there was a typo [here](https://github.com/r-quantities/units/commit/956062cf13641bc20d205d4b4066437d558582b8#diff-2711d8988b4edf6562a0668d7e873c13R25), so `udunits_exit` was not being called.

