### PR TITLE
update R Journal citation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,6 +32,9 @@ Description: Support for measurement units in R vectors, matrices
 	incompatibility. Compatible with the POSIXct, Date and difftime 
 	classes. Uses the UNIDATA udunits library and unit database for 
 	unit compatibility checking and conversion.
+	Documentation about 'units' is provided in the paper by Pebesma, Mailund &
+  Hiebert (2016, <doi:10.32614/RJ-2016-061>), included in this package as a
+  vignette; see 'citation("units")' for details.
 SystemRequirements: udunits-2
 License: GPL-2
 URL: https://github.com/r-quantities/units/

--- a/README.md
+++ b/README.md
@@ -6,13 +6,30 @@
 [![License](http://img.shields.io/badge/license-GPL%20%28%3E=%202%29-brightgreen.svg?style=flat)](http://www.gnu.org/licenses/gpl-2.0.html) [![CRAN](http://www.r-pkg.org/badges/version/units)](https://cran.r-project.org/package=units) 
 [![Downloads](http://cranlogs.r-pkg.org/badges/units?color=brightgreen)](http://www.r-pkg.org/pkg/units)
 
-### News
-Cite this package as _Edzer Pebesma, Thomas Mailund and James
-Hiebert, 2016.  Measurement Units in R.  [The R Journal, 8 (2),
-486--494.](https://journal.r-project.org/archive/2016/RJ-2016-061/index.html)_.
+Support for measurement units in R vectors, matrices
+and arrays: automatic propagation, conversion, derivation
+and simplification of units; raising errors in case of unit
+incompatibility. Compatible with the POSIXct, Date and difftime 
+classes. Uses the UNIDATA udunits library and unit database for 
+unit compatibility checking and conversion.
+
+### Documentation
+
+Documentation is provided in an R Journal publication. Cite this package as:
+
+- Edzer Pebesma, Thomas Mailund and James Hiebert (2016). "Measurement Units in R."
+  _The R Journal_, 8 (2), 486--494. 
+  DOI: [10.32614/RJ-2016-061](https://doi.org/10.32614/RJ-2016-061)
+
 The main units
 [vignette](https://r-quantities.github.io/units/articles/measurement_units_in_R.html)
 derives from this manuscript and is kept up to date with the package development.
+
+- Blog posts: [first](http://r-spatial.org/r/2016/06/10/units.html),
+  [second](http://r-spatial.org/r/2016/08/16/units2.html),
+  [third](http://r-spatial.org/r/2016/09/29/plot_units.html).
+- The [udunits2 R package](https://github.com/pacificclimate/Rudunits2) GitHub page.
+- The UNIDATA [udunits2](https://github.com/Unidata/UDUNITS-2) library at GitHub.
 
 ### What it does
 
@@ -39,12 +56,6 @@ spd1 * set_units(10, s) # unit simplification
 spd1 + set_units(10, s) # error checking
 #   cannot convert s into m/s
 ```
-
-* blog posts: [first](http://r-spatial.org/r/2016/06/10/units.html), [second](http://r-spatial.org/r/2016/08/16/units2.html), [third](http://r-spatial.org/r/2016/09/29/plot_units.html)
-* [package vignette](https://cran.r-project.org/web/packages/units/vignettes/units.html)
-* The [R Journal publication](https://journal.r-project.org/archive/2016-2/pebesma-mailund-hiebert.pdf), which has been [updated to recent package developments](https://r-quantities.github.io/units/articles/measurement_units_in_R.html)
-* the [udunits2 R package](https://github.com/pacificclimate/Rudunits2) github page
-* the UNIDATA [udunits2](https://github.com/Unidata/UDUNITS-2) library at github
 
 ### Installation
 

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,16 +1,14 @@
-citHeader("To cite package units in publications use:")
-
-citEntry(entry="Article",
-  author       = personList(as.person("Edzer Pebesma"), as.person("Thomas Mailund"), as.person("James Hiebert")),
-  title        = "Measurement Units in {R}", 
-  journal      = "The R Journal",
-  year         = 2016,
-  volume       = 8,
-  number       = 2,
-  pages        = "486--494",
-  month        = "december",
-  url          = "https://journal.r-project.org/archive/2016/RJ-2016-061/",
-  textVersion = 
-   paste("Edzer Pebesma, Thomas Mailund and James Hiebert, 2016.  Measurement Units in R.",
-	"The R Journal, 8 (2), 486--494")
+bibentry(
+  header  = "To cite 'units' in publications use:",
+  bibtype = "Article",
+  title   = "Measurement Units in {R}",
+  author  = c(person("Edzer", "Pebesma"),
+              person("Thomas", "Mailund"),
+              person("James", "Hiebert")),
+  year    = "2016",
+  journal = "R Journal",
+  doi     = "10.32614/RJ-2016-061",
+  pages   = "486--494",
+  volume  = "8",
+  number  = "2"
 )

--- a/vignettes/measurement_units_in_R.bib
+++ b/vignettes/measurement_units_in_R.bib
@@ -249,12 +249,11 @@ publisher = {CRC Inc}
 
 @article{rj,
   author       = {Edzer Pebesma and Thomas Mailund and James Hiebert},
-  title        = {Measurement Units in {R}}, 
-  journal      = {The R Journal},
+  title        = {{Measurement Units in R}}, 
+  journal      = {{The R Journal}},
   year         = 2016,
   volume       = 8,
   number       = 2,
   pages        = {486--494},
-  month        = "december",
-  url          = "https://journal.r-project.org/archive/2016/RJ-2016-061/"
+  doi          = {10.32614/RJ-2016-061}
 }

--- a/vignettes/measurement_units_in_R.html
+++ b/vignettes/measurement_units_in_R.html
@@ -527,7 +527,7 @@ as.Date(d1)
 <p>Pebesma, Edzer, and Roger Bivand. 2005. “Classes and Methods for Spatial Data in R.” <em>R News</em> 5 (2): 9–13. <a href=" https://cran.r-project.org/doc/Rnews/">https://cran.r-project.org/doc/Rnews/</a>.</p>
 </div>
 <div id="ref-rj">
-<p>Pebesma, Edzer, Thomas Mailund, and James Hiebert. 2016. “Measurement Units in R.” <em>The R Journal</em> 8 (2): 486–94. <a href="https://journal.r-project.org/archive/2016/RJ-2016-061/" class="uri">https://journal.r-project.org/archive/2016/RJ-2016-061/</a>.</p>
+<p>Pebesma, Edzer, Thomas Mailund, and James Hiebert. 2016. “Measurement Units in R.” <em>The R Journal</em> 8 (2): 486–94. <a href="https://doi.org/10.32614/RJ-2016-061">https://doi.org/10.32614/RJ-2016-061</a>.</p>
 </div>
 <div id="ref-ggforce">
 <p>Pedersen, Thomas Lin. 2016. <em>Ggforce: Accelerating ’Ggplot2’</em>. <a href="https://CRAN.R-project.org/package=ggforce" class="uri">https://CRAN.R-project.org/package=ggforce</a>.</p>


### PR DESCRIPTION
Now R Journal publications [have a DOI](https://journal.r-project.org/archive/2016/RJ-2016-061/index.html)! Changes here:

- DOI added to DESCRIPTION
- Reference updated in README + minor rewriting
- Reference updated in CITATION + update to newer method `bibentry`
- Reference updated in `.bib` and `.html` under `vignettes`