### PR TITLE
Fix #208: validate units before installation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * fix support for weights with units in `weighted.mean`; #205
 
+* invalid names for new units now trigger a proper error message; #209 addressing #208
+
 # version 0.6-3
 
 * improve platform dependent encodings handling; #183

--- a/R/deprecated.R
+++ b/R/deprecated.R
@@ -9,7 +9,7 @@
 #' @rdname deprecated
 make_unit <- function(chr) {
   .Deprecated("as_units", msg = "make_unit() is deprecated. Please use as_units()")
-  if (! is_valid_unit_symbol(chr))
+  if (!ud_is_parseable(chr))
     warning(paste(sQuote(chr), "is not a valid unit symbol recognized by udunits"), call.=FALSE)
   as_units.character(chr, force_single_symbol = TRUE, check_is_valid = FALSE)
 }

--- a/R/make_units.R
+++ b/R/make_units.R
@@ -296,10 +296,6 @@ pc_and <- function(..., sep = "") {
     "Prefixes will automatically work with any user-defined unit.")
 }
 
-is_valid_unit_symbol <- function(chr) {
-  ud_is_parseable(chr)
-}
-
 units_eval_env <- new.env(parent = baseenv())
 units_eval_env$ln <- function(x) base::log(x)
 units_eval_env$lg <- function(x) base::log(x, base = 10)
@@ -350,7 +346,7 @@ as_units.call <- function(x, check_is_valid = TRUE, ...) {
 See ?as_units for usage examples.")
   
   if (check_is_valid) {
-    valid <- vapply(vars, is_valid_unit_symbol, logical(1L))
+    valid <- vapply(vars, ud_is_parseable, logical(1L))
     if (!all(valid))
       stop(.msg_units_not_recognized(vars[!valid], x), call. = FALSE)
   }
@@ -388,7 +384,7 @@ symbolic_unit <- function(chr, check_is_valid = TRUE) {
   
   stopifnot(is.character(chr), length(chr) == 1)
   
-  if (check_is_valid && !is_valid_unit_symbol(chr)) {
+  if (check_is_valid && !ud_is_parseable(chr)) {
     msg <- paste(sQuote(chr), "is not a unit recognized by udunits or a user-defined unit")
     stop(msg, call. = FALSE)
   }

--- a/tests/testthat/test_user_conversion.R
+++ b/tests/testthat/test_user_conversion.R
@@ -61,3 +61,17 @@ test_that("removing units works", {
   expect_silent(remove_symbolic_unit("foo"))
   expect_error(remove_symbolic_unit("foo"))
 })
+
+test_that("new units' format is checked for possible issues", {
+  wrong_formats <- c(
+    " 2asdf", "asdf2 ", 
+    "as+df", "as-df", "as*df", "as/df", "as^df",
+    "as df")
+  for (i in wrong_formats) {
+    expect_error(install_symbolic_unit(i))
+    expect_error(install_conversion_constant(i, "m", 2))
+    expect_error(install_conversion_constant("m", i, 2))
+    expect_error(install_conversion_offset(i, "m", 2))
+    expect_error(install_conversion_offset("m", i, 2))
+  }
+})


### PR DESCRIPTION
Current checks:

- Leading and trailing numbers.
- Arithmetic operators.
- Intermediate white spaces.

Am I missing something?