### PR TITLE
close #232: fix replacement of parts of units

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,6 +39,6 @@ SystemRequirements: udunits-2
 License: GPL-2
 URL: https://github.com/r-quantities/units/
 BugReports: https://github.com/r-quantities/units/issues/
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.0
 Roxygen: list(old_usage = TRUE)
 Encoding: UTF-8

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,7 +2,9 @@
 
 S3method("[",mixed_units)
 S3method("[",units)
+S3method("[<-",units)
 S3method("[[",units)
+S3method("[[<-",units)
 S3method("units<-",logical)
 S3method("units<-",mixed_units)
 S3method("units<-",numeric)

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * port `isFALSE` to fix regression in old R versions; #230 addressing #229
 
+* fix replacement operation for `units` objects; #233 addressing #232
+
 # version 0.6-6
 
 * prettier `str` print for units and mixed units; #228 addressing #227

--- a/R/misc.R
+++ b/R/misc.R
@@ -1,4 +1,13 @@
 #' @export
+`[<-.units` <- function(x, ..., value) {
+  units(value) <- units(x)
+  NextMethod()
+}
+
+#' @export
+`[[<-.units` <- `[<-.units`
+
+#' @export
 c.units <- function(..., recursive = FALSE, allow_mixed = units_options("allow_mixed")) {
   args <- list(...)
   args[sapply(args, is.null)] <- NULL # remove NULLs

--- a/man/ud_units.Rd
+++ b/man/ud_units.Rd
@@ -4,7 +4,9 @@
 \name{ud_units}
 \alias{ud_units}
 \title{List containing pre-defined units from the udunits2 package.}
-\format{An object of class \code{NULL} of length 0.}
+\format{
+An object of class \code{NULL} of length 0.
+}
 \usage{
 ud_units
 }

--- a/man/unitless.Rd
+++ b/man/unitless.Rd
@@ -4,7 +4,9 @@
 \name{unitless}
 \alias{unitless}
 \title{The "unit" type for vectors that are actually dimension-less.}
-\format{An object of class \code{symbolic_units} of length 2.}
+\format{
+An object of class \code{symbolic_units} of length 2.
+}
 \usage{
 unitless
 }

--- a/tests/testthat/test_misc.R
+++ b/tests/testthat/test_misc.R
@@ -1,5 +1,26 @@
 context("Misc. utility functions")
 
+test_that("We can replace parts if they have an equivalent unit", {
+  x <- 1:4 * as_units("km")
+  y <- c(3000, 4000) * as_units("m")
+  z <- 5000 * as_units("m")
+  x[3:4] <- y
+  x[[5]] <- z
+
+  expect_length(x, 5)
+  expect_equal(as.numeric(x), 1:5)
+  expect_equal(as.character(units(x)), "km")
+})
+
+test_that("We can't replace parts if they have different unit", {
+  x <- 1:4 * as_units("km")
+  y <- c(3000, 4000) * as_units("s")
+  z <- 5000 * as_units("s")
+
+  expect_error(x[3:4] <- y)
+  expect_error(x[[5]] <- z)
+})
+
 test_that("We can concatenate units if they have the same unit", {
   x <- 1:4 * as_units("m")
   y <- 5:8 * as_units("m")


### PR DESCRIPTION
With this patch,

```r
x <- set_units(24, h)
x[2] <- set_units(1440, min)
x
#> Units: [h]
#> [1] 24 24

x[2] <- set_units(3, m)
#> Error: cannot convert m into h

h <- data.frame(dt = set_units(24, "h"))
min <- data.frame(dt = set_units(1440, "min"))
rbind(h, min)
#>       dt
#> 1 24 [h]
#> 2 24 [h]
rbind(min, h)
#>           dt
#> 1 1440 [min]
#> 2 1440 [min]
```