### PR TITLE
[ and [[ keep attributes

### DIFF
--- a/R/conversion.R
+++ b/R/conversion.R
@@ -194,12 +194,14 @@ as_difftime <- function(x) {
 
 
 #' @export
-`[.units` <- function(x, i, j, ..., drop = TRUE)
-  .as.units(NextMethod(), units(x))
+`[.units` <- function(x, i, j, ..., drop = TRUE) {
+  restore_units(NextMethod(), x)
+}
 
 #' @export
-`[[.units` <- function(x, i, j, ...)
-  .as.units(NextMethod(), units(x))
+`[[.units` <- function(x, i, j, ...) {
+  restore_units(NextMethod(), x)
+}
 
 #' @export
 as.POSIXct.units = function (x, tz = "UTC", ...) {

--- a/R/make_units.R
+++ b/R/make_units.R
@@ -7,7 +7,7 @@
 }
 
 restore_units <- function(x, to) {
-  out <- .as.units(x, to)
+  out <- .as.units(x, units(to))
   attr(out, "pillar") <- attr(to, "pillar")
   out
 }

--- a/R/make_units.R
+++ b/R/make_units.R
@@ -6,6 +6,16 @@
     structure(x, units = value, dim = dim, class = "units")
 }
 
+restore_units <- function(x, to) {
+  attrs <- attributes(to)
+  attrs$names <- NULL
+  attrs$dim <- NULL
+  attrs$dimnams <- NULL
+
+  attributes(x)[names(attrs)] <- attrs
+  x
+}
+
 #' @name units
 #' @export
 #'

--- a/R/make_units.R
+++ b/R/make_units.R
@@ -7,13 +7,9 @@
 }
 
 restore_units <- function(x, to) {
-  attrs <- attributes(to)
-  attrs$names <- NULL
-  attrs$dim <- NULL
-  attrs$dimnams <- NULL
-
-  attributes(x)[names(attrs)] <- attrs
-  x
+  out <- .as.units(x, to)
+  attr(out, "pillar") <- attr(to, "pillar")
+  out
 }
 
 #' @name units

--- a/tests/testthat/test_misc.R
+++ b/tests/testthat/test_misc.R
@@ -115,10 +115,10 @@ test_that("str works", {
   str(set_units(1/1:3, m/s))
 })
 
-test_that("subsetting keeps attributes", {
+test_that("subsetting keeps pillar attribute (#275)", {
   x <- set_units(1:3, m)
-  attr(x, "foo") <- "bar"
+  attr(x, "pillar") <- "bar"
 
-  expect_equal(attr(x[1:2], "foo"), "bar")
-  expect_equal(attr(x[[1]], "foo"), "bar")
+  expect_equal(attr(x[1:2], "pillar"), "bar")
+  expect_equal(attr(x[[1]], "pillar"), "bar")
 })

--- a/tests/testthat/test_misc.R
+++ b/tests/testthat/test_misc.R
@@ -114,3 +114,11 @@ test_that("seq works", {
 test_that("str works", {
   str(set_units(1/1:3, m/s))
 })
+
+test_that("subsetting keeps attributes", {
+  x <- set_units(1:3, m)
+  attr(x, "foo") <- "bar"
+
+  expect_equal(attr(x[1:2], "foo"), "bar")
+  expect_equal(attr(x[[1]], "foo"), "bar")
+})


### PR DESCRIPTION
This would be easier and faster if vctrs was an imported package, because we could then use `vec_restore()`.

Do you see strong reasons against importing vctrs? We don't necessarily need to change the class hierarchy, although by inheriting from `"vctrs_vctr"` a lot of code here would be obsolete or could be changed.