### PR TITLE
Use snapshot test for str()

### DIFF
--- a/tests/testthat/_snaps/misc.md
+++ b/tests/testthat/_snaps/misc.md
@@ -1,0 +1,7 @@
+# str works
+
+    Code
+      str(set_units(1 / 1:3, m / s))
+    Output
+       Units: [m/s] num [1:3] 1 0.5 0.333
+

--- a/tests/testthat/test_misc.R
+++ b/tests/testthat/test_misc.R
@@ -112,5 +112,7 @@ test_that("seq works", {
 })
 
 test_that("str works", {
-  str(set_units(1/1:3, m/s))
+  expect_snapshot({
+    str(set_units(1/1:3, m/s))
+  })
 })


### PR DESCRIPTION
possible because we now have testthat >= 3.0.0 .