### PR TITLE
Keep pillar attribute in vec_restore()

### DIFF
--- a/.github/workflows/quantities.yml
+++ b/.github/workflows/quantities.yml
@@ -43,7 +43,7 @@ jobs:
       run: |
         install.packages('remotes')
         deps <- remotes::dev_package_deps("quantities", dependencies=TRUE)
-        saveRDS(deps, ".github/depends.Rds", version=2)
+        saveRDS(deps, "quantities/.github/depends.Rds", version=2)
       shell: Rscript {0}
 
     - name: Cache R packages
@@ -51,7 +51,7 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ${{ env.R_LIBS_USER }}
-        key: ${{ matrix.config.os }}-r-${{ matrix.config.r }}-1-${{ hashFiles('.github/depends.Rds') }}
+        key: ${{ matrix.config.os }}-r-${{ matrix.config.r }}-1-${{ hashFiles('quantities/.github/depends.Rds') }}
         restore-keys: ${{ matrix.config.os }}-r-${{ matrix.config.r }}-1-
 
     - name: Install Linux dependencies

--- a/R/make_units.R
+++ b/R/make_units.R
@@ -6,12 +6,6 @@
     structure(x, units = value, dim = dim, class = "units")
 }
 
-restore_units <- function(x, to) {
-  out <- .as.units(x, units(to))
-  attr(out, "pillar") <- attr(to, "pillar")
-  out
-}
-
 #' @name units
 #' @export
 #'

--- a/R/tidyverse.R
+++ b/R/tidyverse.R
@@ -30,7 +30,12 @@ vec_proxy.units = function(x, ...) {
   x
 }
 vec_restore.units = function(x, to, ...) {
-  set_units(x, units(to), mode = "standard")
+  restore_units(x, to)
+}
+restore_units <- function(x, to) {
+  out <- .as.units(x, units(to))
+  attr(out, "pillar") <- attr(to, "pillar")
+  out
 }
 
 


### PR DESCRIPTION
Required for `vec_slice()`. Follow-up to #275.