### PR TITLE
Always allow division of identical units

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# development version
+
+* identical units will always divide (`/`) and allow integer division (`%/%`);
+  #310 @billdenney
+
 # version 0.8-1
 
 * fix `%/%` and `%%` if arguments have different units; #313

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # development version
 
-* identical units will always divide (`/`) and allow integer division (`%/%`);
-  #310 @billdenney
+* Identical units will always divide (`/`) and allow integer division (`%/%`).
+  And, inverse units will always be able to multiply; #310 @billdenney
 
 # version 0.8-1
 

--- a/R/arith.R
+++ b/R/arith.R
@@ -71,18 +71,12 @@ Ops.units <- function(e1, e2) {
     identical(units(e1)$numerator, units(e2)$denominator) &&
     identical(units(e1)$denominator, units(e2)$numerator)
 
-  if (div && identical_units) {
-    # Special cases for identical units which may not be otherwise divisible by
-    # udunits (see #310)
-    if (.Generic == "%/%") {
-      return(set_units(drop_units(e1) %/% drop_units(e2), 1))
-    } else if (.Generic == "/") {
-      return(set_units(drop_units(e1)/drop_units(e2), 1))
-    } else {
-      stop("Unknown division .Generic, please report a bug") # nocov
-    }
-  } else if (mul && inverse_units) {
-    return(set_units(drop_units(e1) * drop_units(e2), 1))
+  if ((div && identical_units) | (mul && inverse_units)) {
+    # Special cases for identical unit division and inverse unit multiplication
+    # which may not be otherwise divisible by udunits (see #310)
+    e1 <- drop_units(e1)
+    e2 <- drop_units(e2)
+    return(set_units(NextMethod(), 1))
   } else if (mod) {
     div <- e1 / e2
     int <- round(div)

--- a/R/arith.R
+++ b/R/arith.R
@@ -46,7 +46,7 @@ Ops.units <- function(e1, e2) {
     return(NextMethod())
 
   eq  <- .Generic %in% c("+", "-", "==", "!=", "<", ">", "<=", ">=") # requiring identical units
-  div <- .Generic %in% c("/", "%/%")
+  div <- .Generic %in% c("/", "%/%")                                 # division-type
   prd <- .Generic %in% c("*", "/", "%/%", "%%")                      # product-type
   pw  <- .Generic %in% c( "**", "^")                                 # power-type
   mod <- .Generic %in% c("%/%", "%%")                                # modulo-type
@@ -61,13 +61,19 @@ Ops.units <- function(e1, e2) {
     units(e2) <- units(e1) # convert before we can compare; errors if unconvertible
   }
 
-  if (div & identical(units(e1), units(e2))) {
-    # Special cases for identical units which may not be otherwise divisible
-    # (see #310)
+  identical_units <-
+    inherits(e1, "units") & inherits(e2, "units") &&
+    identical(units(e1), units(e2))
+
+  if (div & identical_units) {
+    # Special cases for identical units which may not be otherwise divisible by
+    # udunits (see #310)
     if (.Generic == "%/%") {
-      return(set_units(as.numeric(e2) %/% as.numeric(e2), ""))
+      return(set_units(as.numeric(e1) %/% as.numeric(e2), ""))
     } else if (.Generic == "/") {
       return(set_units(as.numeric(e1)/as.numeric(e2), ""))
+    } else {
+      stop("Unknown division .Generic, please report a bug") # nocov
     }
   } else if (mod) {
     div <- e1 / e2

--- a/R/arith.R
+++ b/R/arith.R
@@ -62,16 +62,16 @@ Ops.units <- function(e1, e2) {
   }
 
   identical_units <-
-    inherits(e1, "units") & inherits(e2, "units") &&
+    inherits(e1, "units") && inherits(e2, "units") &&
     identical(units(e1), units(e2))
 
-  if (div & identical_units) {
+  if (div && identical_units) {
     # Special cases for identical units which may not be otherwise divisible by
     # udunits (see #310)
     if (.Generic == "%/%") {
-      return(set_units(as.numeric(e1) %/% as.numeric(e2), ""))
+      return(set_units(drop_units(e1) %/% drop_units(e2), 1))
     } else if (.Generic == "/") {
-      return(set_units(as.numeric(e1)/as.numeric(e2), ""))
+      return(set_units(drop_units(e1)/drop_units(e2), 1))
     } else {
       stop("Unknown division .Generic, please report a bug") # nocov
     }

--- a/R/arith.R
+++ b/R/arith.R
@@ -47,8 +47,9 @@ Ops.units <- function(e1, e2) {
 
   eq  <- .Generic %in% c("+", "-", "==", "!=", "<", ">", "<=", ">=") # requiring identical units
   div <- .Generic %in% c("/", "%/%")                                 # division-type
+  mul <- .Generic %in% "*"                                           # multiplication-only
   prd <- .Generic %in% c("*", "/", "%/%", "%%")                      # product-type
-  pw  <- .Generic %in% c( "**", "^")                                 # power-type
+  pw  <- .Generic %in% c("**", "^")                                  # power-type
   mod <- .Generic %in% c("%/%", "%%")                                # modulo-type
   pm  <- .Generic %in% c("+", "-")                                   # addition-type
 
@@ -65,6 +66,11 @@ Ops.units <- function(e1, e2) {
     inherits(e1, "units") && inherits(e2, "units") &&
     identical(units(e1), units(e2))
 
+  inverse_units <-
+    inherits(e1, "units") && inherits(e2, "units") &&
+    identical(units(e1)$numerator, units(e2)$denominator) &&
+    identical(units(e1)$denominator, units(e2)$numerator)
+
   if (div && identical_units) {
     # Special cases for identical units which may not be otherwise divisible by
     # udunits (see #310)
@@ -75,6 +81,8 @@ Ops.units <- function(e1, e2) {
     } else {
       stop("Unknown division .Generic, please report a bug") # nocov
     }
+  } else if (mul && inverse_units) {
+    return(set_units(drop_units(e1) * drop_units(e2), 1))
   } else if (mod) {
     div <- e1 / e2
     int <- round(div)

--- a/R/arith.R
+++ b/R/arith.R
@@ -46,6 +46,7 @@ Ops.units <- function(e1, e2) {
     return(NextMethod())
 
   eq  <- .Generic %in% c("+", "-", "==", "!=", "<", ">", "<=", ">=") # requiring identical units
+  div <- .Generic %in% c("/", "%/%")
   prd <- .Generic %in% c("*", "/", "%/%", "%%")                      # product-type
   pw  <- .Generic %in% c( "**", "^")                                 # power-type
   mod <- .Generic %in% c("%/%", "%%")                                # modulo-type
@@ -60,7 +61,15 @@ Ops.units <- function(e1, e2) {
     units(e2) <- units(e1) # convert before we can compare; errors if unconvertible
   }
 
-  if (mod) {
+  if (div & identical(units(e1), units(e2))) {
+    # Special cases for identical units which may not be otherwise divisible
+    # (see #310)
+    if (.Generic == "%/%") {
+      return(set_units(as.numeric(e2) %/% as.numeric(e2), ""))
+    } else if (.Generic == "/") {
+      return(set_units(as.numeric(e1)/as.numeric(e2), ""))
+    }
+  } else if (mod) {
     div <- e1 / e2
     int <- round(div)
     if (.Generic == "%/%") {

--- a/tests/testthat/test_arith.R
+++ b/tests/testthat/test_arith.R
@@ -204,7 +204,7 @@ test_that("identical units can always be divided and return unitless (#310)", {
     set_units(log(100)/log(4), "")
   )
   expect_equal(
-    x1%/%x2,
-    set_units(3, "")
+    x1 %/% x2,
+    set_units(log(100) %/% log(4), "")
   )
 })

--- a/tests/testthat/test_arith.R
+++ b/tests/testthat/test_arith.R
@@ -195,3 +195,16 @@ test_that("we obtain mixed units when taking powers of multiple integers", {
   p = 4:1
   expect_equal(a ^ p, c(set_units(1, m^4), set_units(8, m^3), set_units(9, m^2), set_units(4, m),  allow_mixed=TRUE))
 })
+
+test_that("identical units can always be divided and return unitless (#310)", {
+  x1 <- log(set_units(100, "g"))
+  x2 <- log(set_units(4, "g"))
+  expect_equal(
+    x1/x2,
+    set_units(log(100)/log(4), "")
+  )
+  expect_equal(
+    x1%/%x2,
+    set_units(3, "")
+  )
+})

--- a/tests/testthat/test_arith.R
+++ b/tests/testthat/test_arith.R
@@ -208,3 +208,13 @@ test_that("identical units can always be divided and return unitless (#310)", {
     set_units(log(100) %/% log(4), "")
   )
 })
+
+test_that("inverse units can always be multiplied and return unitless (related to #310)", {
+  x1 <- log(set_units(100, "g"))
+  x2 <- log(set_units(4, "g"))
+  expect_equal(
+    x1*(1/x2),
+    set_units(log(100)/log(4), "")
+  )
+})
+


### PR DESCRIPTION
Fix #310

This always allows division of units, if they are equal, and it returns a unitless object.