### PR TITLE
Always allow comparisons to logical or numeric NA

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# development version
+
+* NA to unit comparisons (for logical and numeric NA) will always return NA;
+  #308 @billdenney
+
 # version 0.8-1
 
 * fix `%/%` and `%%` if arguments have different units; #313

--- a/R/arith.R
+++ b/R/arith.R
@@ -56,7 +56,7 @@ Ops.units <- function(e1, e2) {
 
   if (eq) {
     if (!(inherits(e1, "units") && inherits(e2, "units")))
-      stop("both operands of the expression should be \"units\" objects") # nocov
+      stop("both operands of the expression should be \"units\" objects")
     units(e2) <- units(e1) # convert before we can compare; errors if unconvertible
   }
 

--- a/R/arith.R
+++ b/R/arith.R
@@ -55,9 +55,22 @@ Ops.units <- function(e1, e2) {
     stop(paste("operation", .Generic, "not allowed"))
 
   if (eq) {
-    if (!(inherits(e1, "units") && inherits(e2, "units")))
-      stop("both operands of the expression should be \"units\" objects")
-    units(e2) <- units(e1) # convert before we can compare; errors if unconvertible
+    # If one side is all numeric or logical NA, then set the units for that to
+    # the same as the other side's units.  That allows NA input to give NA
+    # output with units.
+    e1_units <- inherits(e1, "units")
+    e2_units <- inherits(e2, "units")
+    e1_allowed <- (is.logical(e1) | is.numeric(e1)) & all(is.na(e1))
+    e2_allowed <- (is.logical(e2) | is.numeric(e2)) & all(is.na(e2))
+    if (e1_units & e2_allowed) {
+      units(e2) <- units(e1)
+    } else if (e1_allowed & e2_units) {
+      units(e1) <- units(e2)
+    } else {
+      if (!(inherits(e1, "units") && inherits(e2, "units")))
+        stop("both operands of the expression should be \"units\" objects")
+      units(e2) <- units(e1) # convert before we can compare; errors if unconvertible
+    }
   }
 
   if (mod) {

--- a/tests/testthat/test_arith.R
+++ b/tests/testthat/test_arith.R
@@ -202,3 +202,28 @@ test_that("test for comparison where one side does not have units", {
     regexp = 'both operands of the expression should be "units" objects'
   )
 })
+
+test_that("test for comparison where one side does not have units and is all NA (#308)", {
+  expect_equal(
+    set_units(1, "") == NA,
+    NA
+  )
+  expect_equal(
+    NA == set_units(1, "m"),
+    NA
+  )
+  expect_equal(
+    NA_real_ == set_units(1:3, "m"),
+    rep(NA, 3)
+  )
+  # Comparison to character does not make sense, so it does not work
+  expect_error(
+    NA_character_ == set_units(1:3, "m"),
+    regexp = 'both operands of the expression should be "units" objects'
+  )
+  # Comparison when any value is not NA fails
+  expect_error(
+    c(1, NA, NA) == set_units(1:3, "m"),
+    regexp = 'both operands of the expression should be "units" objects'
+  )
+})

--- a/tests/testthat/test_arith.R
+++ b/tests/testthat/test_arith.R
@@ -195,3 +195,10 @@ test_that("we obtain mixed units when taking powers of multiple integers", {
   p = 4:1
   expect_equal(a ^ p, c(set_units(1, m^4), set_units(8, m^3), set_units(9, m^2), set_units(4, m),  allow_mixed=TRUE))
 })
+
+test_that("test for comparison where one side does not have units", {
+  expect_error(
+    set_units(1, "") == 1,
+    regexp = 'both operands of the expression should be "units" objects'
+  )
+})


### PR DESCRIPTION
Fix #308

This always allows comparison to numeric or logical NA (and it adds a test for non-NA comparisons, too).