### PR TITLE
Preserve names with unit conversion

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# development version
+
+* Names are preserved when doing unit conversions; #305 @billdenney
+
 # version 0.8-1
 
 * fix `%/%` and `%%` if arguments have different units; #313

--- a/R/conversion.R
+++ b/R/conversion.R
@@ -67,7 +67,7 @@
 #' units(a) <- make_units(km/h)
 #' a
 #' # convert to a mixed_units object:
-#' units(a) = c("m/s", "km/h", "km/h")
+#' units(a) <- c("m/s", "km/h", "km/h")
 #' a
 `units<-.units` <- function(x, value) {
   if(is.null(value))

--- a/R/conversion.R
+++ b/R/conversion.R
@@ -93,10 +93,7 @@
   str2 <- as.character(value)
 
   if (ud_are_convertible(str1, str2))
-    setNames(
-      .as.units(ud_convert(unclass(x), str1, str2), value, dim = dimx),
-      nm = names(x)
-    )
+    .as.units(ud_convert(unclass(x), str1, str2), value, dim = dimx)
   else
     stop(paste("cannot convert", units(x), "into", value), call. = FALSE)
 }

--- a/R/conversion.R
+++ b/R/conversion.R
@@ -70,13 +70,12 @@
 #' units(a) = c("m/s", "km/h", "km/h")
 #' a
 `units<-.units` <- function(x, value) {
-
   if(is.null(value))
     return(drop_units(x))
 
   if(!inherits(value, "units") && !inherits(value, "symbolic_units")) {
-	if ((is.character(value) && length(value) > 1))
-	  return(set_units(mixed_units(x), value))
+    if ((is.character(value) && length(value) > 1))
+      return(set_units(mixed_units(x), value))
     value <- as_units(value)
   }
 
@@ -94,7 +93,10 @@
   str2 <- as.character(value)
 
   if (ud_are_convertible(str1, str2))
-    .as.units(ud_convert(unclass(x), str1, str2), value, dim = dimx)
+    setNames(
+      .as.units(ud_convert(unclass(x), str1, str2), value, dim = dimx),
+      nm = names(x)
+    )
   else
     stop(paste("cannot convert", units(x), "into", value), call. = FALSE)
 }

--- a/man/units.Rd
+++ b/man/units.Rd
@@ -195,7 +195,7 @@ a <- set_units(1:3, m/s)
 units(a) <- make_units(km/h)
 a
 # convert to a mixed_units object:
-units(a) = c("m/s", "km/h", "km/h")
+units(a) <- c("m/s", "km/h", "km/h")
 a
 # The easiest way to assign units to a numeric vector is like this:
 x <- y <- 1:4

--- a/src/udunits.cpp
+++ b/src/udunits.cpp
@@ -84,13 +84,12 @@ NumericVector ud_convert(NumericVector val, CharacterVector from, CharacterVecto
   ut_unit *u_to = ut_parse(sys, ut_trim(to[0], enc), enc);
 
   cv_converter *cv = ut_get_converter(u_from, u_to);
-  NumericVector out(val.size());
-  cv_convert_doubles(cv, &(val[0]), val.size(), &(out[0]));
+  cv_convert_doubles(cv, &(val[0]), val.size(), &(val[0]));
 
   cv_free(cv);
   ut_free(u_from);
   ut_free(u_to);
-  return out;
+  return val;
 }
 
 // [[Rcpp::export]]

--- a/tests/testthat/test_conversion.R
+++ b/tests/testthat/test_conversion.R
@@ -214,5 +214,12 @@ test_that("ud_are_convertible return the expected value", {
   expect_true(ud_are_convertible("m", "km"))
   expect_true(ud_are_convertible(units(x), "km"))
   expect_false(ud_are_convertible("s", "kg"))
+})
 
+test_that("set_units keeps names even with unit conversion (#305)", {
+  expect_named(set_units(c(a=1), "m"), "a")
+  expect_named(
+    set_units(set_units(c(a=1), "m"), "km"),
+    "a"
+  )
 })

--- a/tests/testthat/test_conversion.R
+++ b/tests/testthat/test_conversion.R
@@ -223,3 +223,14 @@ test_that("set_units keeps names even with unit conversion (#305)", {
     "a"
   )
 })
+
+test_that("conversion to mixed_units", {
+  a <- set_units(1:3, m/s)
+  expect_s3_class(a, "units")
+  units(a) <- c("m/s", "km/h", "km/h")
+  expect_s3_class(a, "mixed_units")
+  expect_equal(
+    drop_units(a),
+    c(1, 0.002*3600, 0.003*3600)
+  )
+})


### PR DESCRIPTION
Fix #305

Now, names are preserved with unit conversion.  The underlying issue is that the C-connection function `ud_convert` drops the names.  I don't know how to fix that, and it seems to be used only at the location that I found in the code.