### PR TITLE
add passthrough for `keep_units()` when units are not provided

### DIFF
--- a/R/helpers.R
+++ b/R/helpers.R
@@ -19,7 +19,7 @@
 #'
 #' @export
 keep_units <- function(FUN, x, ..., unit=units(x)) {
-  if (inherits(x, "units") || inherits(unit, "symbolic_units")) {
+  if (inherits(try(unit, silent = TRUE), "symbolic_units")) {
     set_units(do.call(FUN, list(x, ...)), unit, mode = "standard")
   } else {
     warning("`x` does not have units.") # maybe not necessary to warn?

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -6,6 +6,11 @@
 #' Provided for incompatible functions that do not preserve units. The user is
 #' responsible for ensuring the correctness of the output.
 #'
+#' If \code{x} is not a \code{units} object
+#' and \code{unit} is not provided by the user,
+#' a warning is issued, and the output will also have no units
+#' (see examples).
+#'
 #' @param FUN the function to be applied.
 #' @param x first argument of \code{FUN}, of class \code{units}.
 #' @param ... optional arguments to \code{FUN}.
@@ -17,12 +22,25 @@
 #' x <- set_units(1:5, m)
 #' keep_units(drop_units, x)
 #'
+#' # An example use case is with random number generating functions:
+#' mu <- as_units(10, "years")
+#' keep_units(rnorm, n = 1, x = mu)
+#'
+#' # units can be directly specified if needed:
+#' rate <- as_units(3, "1/year")
+#' keep_units(rexp, n = 1, x = rate, unit = units(1/rate))
+#'
+#' # if `x` does not actually have units, a warning is issued,
+#' # and the output has no units:
+#' rate2 <- 3
+#' keep_units(rexp, n = 1, x = rate2)
+#'
 #' @export
 keep_units <- function(FUN, x, ..., unit=units(x)) {
   if (inherits(try(unit, silent = TRUE), "symbolic_units")) {
     set_units(do.call(FUN, list(x, ...)), unit, mode = "standard")
   } else {
-    warning("`x` does not have units.")
+    warning("wrong `unit` specification.")
     do.call(FUN, list(x, ...))
   }
 }

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -26,7 +26,9 @@
 #' mu <- as_units(10, "years")
 #' keep_units(rnorm, n = 1, x = mu)
 #'
-#' # units can be directly specified if needed:
+#' # units can be directly specified if needed; for example, with
+#' # `rexp()`, the units of the rate parameter are the inverse of
+#' # the units of the output:
 #' rate <- as_units(3, "1/year")
 #' keep_units(rexp, n = 1, x = rate, unit = units(1/rate))
 #'

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -22,7 +22,7 @@ keep_units <- function(FUN, x, ..., unit=units(x)) {
   if (inherits(try(unit, silent = TRUE), "symbolic_units")) {
     set_units(do.call(FUN, list(x, ...)), unit, mode = "standard")
   } else {
-    warning("`x` does not have units.") # maybe not necessary to warn?
+    warning("`x` does not have units.")
     do.call(FUN, list(x, ...))
   }
 }

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -19,7 +19,12 @@
 #'
 #' @export
 keep_units <- function(FUN, x, ..., unit=units(x)) {
-  set_units(do.call(FUN, list(x, ...)), unit, mode="standard")
+  if (inherits(x, "units")) {
+    set_units(do.call(FUN, list(x, ...)), unit, mode = "standard")
+  } else {
+    warning("`x` does not have units.") # maybe not necessary to warn?
+    do.call(FUN, list(x, ...))
+  }
 }
 
 dfapply <- function(X, FUN, ...) {

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -19,7 +19,7 @@
 #'
 #' @export
 keep_units <- function(FUN, x, ..., unit=units(x)) {
-  if (inherits(x, "units")) {
+  if (inherits(x, "units") || inherits(unit, "symbolic_units")) {
     set_units(do.call(FUN, list(x, ...)), unit, mode = "standard")
   } else {
     warning("`x` does not have units.") # maybe not necessary to warn?

--- a/man/keep_units.Rd
+++ b/man/keep_units.Rd
@@ -39,7 +39,9 @@ keep_units(drop_units, x)
 mu <- as_units(10, "years")
 keep_units(rnorm, n = 1, x = mu)
 
-# units can be directly specified if needed:
+# units can be directly specified if needed; for example, with
+# `rexp()`, the units of the rate parameter are the inverse of
+# the units of the output:
 rate <- as_units(3, "1/year")
 keep_units(rexp, n = 1, x = rate, unit = units(1/rate))
 

--- a/man/keep_units.Rd
+++ b/man/keep_units.Rd
@@ -25,9 +25,27 @@ the original units.
 \details{
 Provided for incompatible functions that do not preserve units. The user is
 responsible for ensuring the correctness of the output.
+
+If \code{x} is not a \code{units} object
+and \code{unit} is not provided by the user,
+a warning is issued, and the output will also have no units
+(see examples).
 }
 \examples{
 x <- set_units(1:5, m)
 keep_units(drop_units, x)
+
+# An example use case is with random number generating functions:
+mu <- as_units(10, "years")
+keep_units(rnorm, n = 1, x = mu)
+
+# units can be directly specified if needed:
+rate <- as_units(3, "1/year")
+keep_units(rexp, n = 1, x = rate, unit = units(1/rate))
+
+# if `x` does not actually have units, a warning is issued,
+# and the output has no units:
+rate2 <- 3
+keep_units(rexp, n = 1, x = rate2)
 
 }

--- a/tests/testthat/test_helpers.R
+++ b/tests/testthat/test_helpers.R
@@ -3,3 +3,11 @@ test_that("keep_units restores units", {
 
   expect_identical(x, keep_units(drop_units, x))
 })
+
+test_that("keep_units warns when no units are provide", {
+  x <- 1:5
+
+  expect_warning(keep_units(sum, x))
+
+  expect_identical(suppressWarnings(keep_units(sum, x)), sum(x))
+})

--- a/tests/testthat/test_helpers.R
+++ b/tests/testthat/test_helpers.R
@@ -1,13 +1,20 @@
-test_that("keep_units restores units", {
+test_that("`keep_units()` restores units", {
   x <- set_units(1:5, m)
 
   expect_identical(x, keep_units(drop_units, x))
 })
 
-test_that("keep_units warns when no units are provide", {
+test_that("`keep_units()` warns when no units are provided", {
   x <- 1:5
 
   expect_warning(keep_units(sum, x))
 
   expect_identical(suppressWarnings(keep_units(sum, x)), sum(x))
+})
+
+test_that("`keep_units()` sets units when `unit` argument is provide by user", {
+  rate <- set_units(3, "1/min")
+  x <- keep_units(rexp, 3, rate, unit=units(1/rate))
+  expect_identical(units(x), units(1/rate))
+
 })

--- a/tests/testthat/test_helpers.R
+++ b/tests/testthat/test_helpers.R
@@ -1,10 +1,10 @@
-test_that("`keep_units()` restores units", {
+test_that("keep_units restores units", {
   x <- set_units(1:5, m)
 
   expect_identical(x, keep_units(drop_units, x))
 })
 
-test_that("`keep_units()` warns when no units are provided", {
+test_that("keep_units warns when no units are provided", {
   x <- 1:5
 
   expect_warning(keep_units(sum, x))
@@ -12,7 +12,7 @@ test_that("`keep_units()` warns when no units are provided", {
   expect_identical(suppressWarnings(keep_units(sum, x)), sum(x))
 })
 
-test_that("`keep_units()` sets units when `unit` argument is provide by user", {
+test_that("keep_units sets units when `unit` argument is provide by user", {
   rate <- set_units(3, "1/min")
   x <- keep_units(rexp, 3, rate, unit=units(1/rate))
   expect_identical(units(x), units(1/rate))

--- a/tests/testthat/test_helpers.R
+++ b/tests/testthat/test_helpers.R
@@ -12,7 +12,7 @@ test_that("keep_units warns when no units are provided", {
   expect_identical(suppressWarnings(keep_units(sum, x)), sum(x))
 })
 
-test_that("keep_units sets units when `unit` argument is provide by user", {
+test_that("keep_units sets user-provided units", {
   rate <- set_units(3, "1/min")
   x <- keep_units(rexp, 3, rate, unit=units(1/rate))
   expect_identical(units(x), units(1/rate))


### PR DESCRIPTION
fixes #392