### PR TITLE
Minor edits to documentation and comments

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: units
-Version: 1.0-1.2
+Version: 1.0-1.3
 Title: Measurement Units for R Vectors
 Authors@R: c(person("Edzer", "Pebesma", role = c("aut", "cre"), email = "edzer.pebesma@uni-muenster.de", comment = c(ORCID = "0000-0001-8049-7069")),
     person("Thomas", "Mailund", role = "aut", email = "mailund@birc.au.dk"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * Add `[<-.mixed_units` method; #432
 
+* Several fixes in documentation files; #433 @tszberkowitz
+
 # version 1.0-1
 
 * Add internal workaround for udunits2 bug with parsing of units that contain

--- a/R/conversion.R
+++ b/R/conversion.R
@@ -12,7 +12,7 @@
 #'     \code{make_units(m/s)} is equivalent to \code{as_units(quote(m/s))}.
 #'     \item \code{set_units}, a pipe-friendly version of \code{`units<-`}. By
 #'     default it operates with bare expressions, but this
-#'     behavior can be disabled by a specifying \code{mode = "standard"} or setting
+#'     behavior can be disabled by specifying \code{mode = "standard"} or setting
 #'     \code{units_options(set_units_mode = "standard")}.
 #'     If \code{value} is missing or set to \code{1}, the object becomes unitless.
 #' }
@@ -25,7 +25,7 @@
 #'
 #' @details
 #' If \code{value} is of class \code{units} and has a value unequal to 1, this
-#' value is ignored unless \code{units_options("simplifiy")} is \code{TRUE}. If
+#' value is ignored unless \code{units_options("simplify")} is \code{TRUE}. If
 #' \code{simplify} is \code{TRUE}, \code{x} is multiplied by this value.
 #'
 #' @export
@@ -207,9 +207,9 @@ as.Date.units = function (x, ...) {
 
 #' @param ... passed on to other methods.
 #' @param mode if \code{"symbols"} (the default), then unit is constructed from
-#'   the expression supplied. Otherwise, if\code{mode = "standard"},
-#'   standard evaluation is used for the supplied value This argument can be set
-#'   via a global option \code{units_options(set_units_mode = "standard")}
+#'   the expression supplied. Otherwise, if \code{mode = "standard"},
+#'   standard evaluation is used for the supplied value. This argument can be set
+#'   via a global option \code{units_options(set_units_mode = "standard")}.
 #'
 #' @name units
 #' @export

--- a/R/make_units.R
+++ b/R/make_units.R
@@ -10,7 +10,7 @@
 #' @export
 #'
 #' @param bare_expression a bare R expression describing units. Must be valid R
-#'   syntax (reserved R syntax words like \code{in} must be backticked)
+#'   syntax (reserved R syntax words like \code{in} must be backticked).
 #'
 #' @examples
 #' # The easiest way to assign units to a numeric vector is like this:
@@ -225,12 +225,12 @@ pc_and <- function(..., sep = "") {
 #' @name units
 #' @export
 #'
-#' @param check_is_valid throw an error if all the unit symbols are not either
-#'   recognized by udunits2, or a custom
-#'   user defined via \code{install_unit()}. If \code{FALSE}, no check
+#' @param check_is_valid throw an error if all the unit symbols are either not
+#'   recognized by udunits2 or not custom units
+#'   defined via \code{install_unit()}. If \code{FALSE}, no check
 #'   for validity is performed.
 #'
-#' @param force_single_symbol Whether to perform no string parsing and force
+#' @param force_single_symbol whether to perform no string parsing and force
 #'   treatment of the string as a single symbol.
 #'
 #' @section Character strings:
@@ -269,7 +269,7 @@ pc_and <- function(..., sep = "") {
 #'   otherwise encouraged to use \code{R}'s date and time functionality provided
 #'   by \code{Date} and \code{POSIXt} classes.
 #'
-#' @note By default, unit names are automatically substituted with unit names
+#' @note By default, unit names are automatically substituted with unit symbols
 #'   (e.g., kilogram --> kg). To turn off this behavior, set
 #'   \code{units_options(auto_convert_names_to_symbols = FALSE)}
 #'

--- a/R/make_units.R
+++ b/R/make_units.R
@@ -155,8 +155,10 @@ as_units.symbolic_units <- function(x, value, ...) {
 }
 
 #' @examples
+#' 
+#' # Use difftime object as units
 #' s = Sys.time()
-#' d  = s - (s+1)
+#' d = s - (s+1)
 #' as_units(d)
 #'
 #' @name units

--- a/R/math.R
+++ b/R/math.R
@@ -14,13 +14,12 @@
 #' and \code{lg(...)} respectively instead of \code{ln(...)}.
 #'
 #' This is particularly important for some units that are typically expressed in
-#' a logarithmic scale (i.e., \emph{bels}, or, more commonly, \emph{decibels}),
+#' a logarithmic scale (e.g., \emph{bels}, or, more commonly, \emph{decibels}),
 #' such as Watts or Volts. For some of these units, the default \pkg{udunits2}
 #' database contains aliases: e.g., \code{BW} (bel-Watts) is an alias of
 #' \code{lg(re 1 W)}; \code{Bm} (bel-milliWatts) is an alias of
-#' \code{lg(re 0.001 W)}; \code{BV} is an alias of \code{lg(re 1 V)} (bel-Volts),
-#' and so on and so forth (see the output of \code{valid_udunits()} for further
-#' reference).
+#' \code{lg(re 0.001 W)}; \code{BV} is an alias of \code{lg(re 1 V)} (bel-Volts).
+#' See the output of \code{valid_udunits()} for further reference.
 #'
 #' Additionally, the \pkg{units} package defines \code{B}, the \emph{bel}, by
 #' default (because it is not defined by \pkg{udunits2}) as an alias of

--- a/R/mixed.R
+++ b/R/mixed.R
@@ -6,10 +6,13 @@
 # constructor function:
 #' Create or convert to a mixed units list-column
 #' @param x numeric, or vector of class \code{units}
-#' @param values character vector with units encodings, or list with symbolic units of class \code{mixed_symbolic_units}
+#' @param values character vector with units encodings, or list with symbolic
+#'   units of class \code{mixed_symbolic_units}
 #' @param value see values
 #' @param ... ignored
-#' @details if \code{x} is of class \code{units}, \code{values} should be missing or of class \code{mixed_symbolic_units}; if \code{x} is numeric, \code{values} should be a character vector the length of \code{x}.
+#' @details If \code{x} is of class \code{units}, \code{values} should be
+#'   missing or of class \code{mixed_symbolic_units}; if \code{x} is numeric,
+#'   \code{values} should be a character vector the length of \code{x}.
 #' @examples
 #' a <- 1:4
 #' u <- c("m/s", "km/h", "mg/L", "g")

--- a/R/mixed.R
+++ b/R/mixed.R
@@ -6,13 +6,10 @@
 # constructor function:
 #' Create or convert to a mixed units list-column
 #' @param x numeric, or vector of class \code{units}
-#' @param values character vector with units encodings, or list with symbolic
-#'   units of class \code{mixed_symbolic_units}
+#' @param values character vector with units encodings, or list with symbolic units of class \code{mixed_symbolic_units}
 #' @param value see values
 #' @param ... ignored
-#' @details If \code{x} is of class \code{units}, \code{values} should be
-#'   missing or of class \code{mixed_symbolic_units}; if \code{x} is numeric,
-#'   \code{values} should be a character vector the length of \code{x}.
+#' @details if \code{x} is of class \code{units}, \code{values} should be missing or of class \code{mixed_symbolic_units}; if \code{x} is numeric, \code{values} should be a character vector the length of \code{x}.
 #' @examples
 #' a <- 1:4
 #' u <- c("m/s", "km/h", "mg/L", "g")

--- a/R/plot.R
+++ b/R/plot.R
@@ -2,19 +2,19 @@
 #'
 #' Create axis label with appropriate labels.
 #'
-#' @param lab length one character; name of the variable to plot
+#' @param lab character; name of the variable to plot
 #' @param u vector of class \code{units}
 #' @param sep length two character vector, defaulting to \code{c("~","~")}, with
 #'   the white space between unit name and unit symbols, and between subsequent
-#'   symbols.
+#'   symbols
 #' @param group length two character vector with grouping symbols, e.g.
 #'   \code{c("(",")")} for parenthesis, or \code{c("","")} for no group symbols
 #' @param parse logical; indicates whether a parseable expression should be
-#'   returned (typically needed for super scripts), or a simple character string
-#'   without special formatting.
+#'   returned (typically needed for superscripts), or a simple character string
+#'   without special formatting
 #'
-#' @details \link{units_options} can be used to set and change the defaults for
-#'   \code{sep}, \code{group} and \code{doParse}.
+#' @details \code{\link{units_options}} can be used to set and change the
+#'   defaults for \code{sep}, \code{group} and \code{doParse}.
 #'
 #' @name plot.units
 #' @export
@@ -51,7 +51,8 @@ make_unit_label = function(lab, u,
 
 #' @description Plot method for \code{units} objects.
 #'
-#' @param x object of class units, to plot along the x axis, or, if y is missing, along the y axis
+#' @param x object of class \code{units}, to plot along the x axis or (if
+#'   \code{y} is missing), along the y axis
 #' @param y object to plot along the y axis, or missing
 #' @param xlab character; x axis label
 #' @param ylab character; y axis label
@@ -67,16 +68,16 @@ make_unit_label = function(lab, u,
 #' units_options(group = c("(", ")") )  # parenthesis instead of square brackets
 #' plot(weight, displacement)
 #'
-#' units_options(sep = c("~~~", "~"), group = c("", ""))  # no brackets; extra space
+#' units_options(sep = c("~~~", "~"), group = c("", ""))  # extra space; no brackets
 #' plot(weight, displacement)
 #'
 #' units_options(sep = c("~", "~~"), group = c("[", "]"))
 #' gallon = as_units("gallon")
 #' consumption = mtcars$mpg * make_units(mi/gallon)
 #' units(consumption) = make_units(km/l)
-#' plot(displacement, consumption) # division in consumption
+#' plot(displacement, consumption)  # division in consumption
 #'
-#' units_options(negative_power = TRUE) # division becomes ^-1
+#' units_options(negative_power = TRUE)  # division becomes ^-1
 #' plot(displacement, consumption)
 #'
 #' plot(1/displacement, 1/consumption)
@@ -104,13 +105,13 @@ plot.units <- function(x, y, xlab = NULL, ylab = NULL, ...) {
   NextMethod("plot", xlab=xlab, ylab=ylab)
 }
 
-#' histogram for unit objects
+#' Histogram for \code{units} objects
 #'
-#' histogram for unit objects
-#' @param x object of class units, for which we want to plot the histogram
+#' Histogram for \code{units} objects
+#' @param x object of class \code{units}, for which we want to plot the histogram
 #' @param xlab character; x axis label
 #' @param main character; title of histogram
-#' @param ... parameters passed on to \link{hist.default}
+#' @param ... parameters passed on to \code{\link{hist.default}}
 #' @export
 #' @examples
 #' units_options(parse = FALSE) # otherwise we break on the funny symbol!
@@ -125,13 +126,13 @@ hist.units <- function(x, xlab = NULL, main = paste("Histogram of", xname), ...)
   NextMethod("hist", xlab=xlab, main=main)
 }
 
-#' boxplot for unit objects
+#' Boxplot for \code{units} objects
 #'
-#' boxplot for unit objects
-#' @param x object of class units, for which we want to plot the boxplot
-#' @param ... parameters passed on to \link{boxplot.default}
-#' @param horizontal logical indicating if the boxplots should be horizontal;
-#' default FALSE means vertical boxes.
+#' Boxplot for \code{units} objects
+#' @param x object of class \code{units}, for which we want to plot the boxplot
+#' @param ... parameters passed on to \code{\link{boxplot.default}}
+#' @param horizontal logical; whether boxplots should be horizontal;
+#' default \code{FALSE} means vertical boxes.
 #' @export
 #' @examples
 #' units_options(parse = FALSE) # otherwise we break on the funny symbol!

--- a/R/symbolic_units.R
+++ b/R/symbolic_units.R
@@ -116,7 +116,7 @@ as.character.symbolic_units <- function(x, ...,
 
   # This is just a brute force implementation that takes each element in the
   # numerator and tries to find a value in the denominator that can be converted
-  # to the same unit. It modifies "value" to rescale the nominator to the denominator
+  # to the same unit. It modifies "value" to rescale the numerator to the denominator
   # before removing matching units.
 
   drop_ones = function(u) u[ u != "1" ]
@@ -153,10 +153,10 @@ as.character.symbolic_units <- function(x, ...,
 #' the udunits database (SI units).
 #'
 #' @param x object of class \code{units}.
-#' @param simplify logical; if TRUE (default), the resulting units are simplified.
-#' @param keep_fraction logical; if TRUE (default), the result is kept as a fraction.
+#' @param simplify logical; if \code{TRUE} (default), the resulting units are simplified.
+#' @param keep_fraction logical; if \code{TRUE} (default), the result is kept as a fraction.
 #'
-#' @return object of class \code{units} with units converted to base units.
+#' @return An object of class \code{units} with units converted to base units.
 #' @export
 #'
 #' @examples

--- a/R/valid_udunits.R
+++ b/R/valid_udunits.R
@@ -7,26 +7,26 @@ pcc <- function(...) paste0(..., collapse = ", ")
 #' Get information about valid units
 #'
 #' These functions require the \pkg{xml2} package, and return data frames with
-#' complete information about pre-defined units from UDUNITS2. Inspect this data
-#' frames to determine what inputs are accepted by \code{as_units} (and the
-#' other functions it powers: \code{as_units}, \code{set_units} , \code{units<-}).
+#' complete information about pre-defined units from UDUNITS2. Inspect these
+#' data frames to determine what inputs are accepted by \code{as_units} (and the
+#' other functions it powers: \code{as_units}, \code{set_units}, \code{units<-}).
 #'
-#' Any entry listed under \code{symbol} , \code{symbol_aliases} , \code{
-#' name_singular} , \code{name_singular_aliases} , \code{name_plural} , or
+#' Any entry listed under \code{symbol}, \code{symbol_aliases},
+#' \code{name_singular}, \code{name_singular_aliases}, \code{name_plural} or
 #' \code{name_plural_aliases} is valid. Additionally, any entry under
-#' \code{symbol} or \code{symbol_aliases} may can also contain a valid prefix,
+#' \code{symbol} or \code{symbol_aliases} may also contain a valid prefix,
 #' as specified by \code{valid_udunits_prefixes()} .
 #'
-#' Note, this is primarily intended for interactive use, the exact format of the
+#' Note, this is primarily intended for interactive use. The exact format of the
 #' returned data frames may change in the future.
 #'
-#' @param quiet logical, defaults \code{TRUE} to give a message about the location of
+#' @param quiet logical; \code{FALSE} (default) prints a message about the location of
 #'   the udunits database being read.
 #'
-#' @return a data frame with columns \code{symbol} , \code{symbol_aliases} ,
-#'   \code{name_singular} , \code{name_singular_aliases} , \code{name_plural} ,
-#'   or \code{name_plural_aliases} , \code{def} , \code{definition} ,
-#'   \code{comment} , \code{dimensionless} and \code{source_xml}
+#' @return A data frame with columns \code{symbol}, \code{symbol_aliases},
+#'   \code{name_singular}, \code{name_singular_aliases}, \code{name_plural},
+#'   \code{name_plural_aliases}, \code{def}, \code{definition},
+#'   \code{comment}, \code{dimensionless} and \code{source_xml}.
 #'
 #' @export
 #'
@@ -104,7 +104,7 @@ valid_udunits <- function(quiet = FALSE) {
   })
 
   df <- do.call(rbind, c(l, stringsAsFactors=FALSE, make.row.names=FALSE))
-  class(df) <- c( "tbl_df", "tbl", "data.frame")
+  class(df) <- c("tbl_df", "tbl", "data.frame")
   df
 }
 
@@ -137,6 +137,6 @@ valid_udunits_prefixes <- function(quiet = FALSE) {
 
   df <- do.call(rbind.data.frame,
                 c(l, stringsAsFactors = FALSE, make.row.names = FALSE))
-  class(df) <- c( "tbl_df", "tbl", "data.frame")
+  class(df) <- c("tbl_df", "tbl", "data.frame")
   df
 }

--- a/man/Math.units.Rd
+++ b/man/Math.units.Rd
@@ -22,13 +22,12 @@ library. If a natural logarithm is applied to some \code{unit}, the result is
 and \code{lg(...)} respectively instead of \code{ln(...)}.
 
 This is particularly important for some units that are typically expressed in
-a logarithmic scale (i.e., \emph{bels}, or, more commonly, \emph{decibels}),
+a logarithmic scale (e.g., \emph{bels}, or, more commonly, \emph{decibels}),
 such as Watts or Volts. For some of these units, the default \pkg{udunits2}
 database contains aliases: e.g., \code{BW} (bel-Watts) is an alias of
 \code{lg(re 1 W)}; \code{Bm} (bel-milliWatts) is an alias of
-\code{lg(re 0.001 W)}; \code{BV} is an alias of \code{lg(re 1 V)} (bel-Volts),
-and so on and so forth (see the output of \code{valid_udunits()} for further
-reference).
+\code{lg(re 0.001 W)}; \code{BV} is an alias of \code{lg(re 1 V)} (bel-Volts).
+See the output of \code{valid_udunits()} for further reference.
 
 Additionally, the \pkg{units} package defines \code{B}, the \emph{bel}, by
 default (because it is not defined by \pkg{udunits2}) as an alias of

--- a/man/boxplot.units.Rd
+++ b/man/boxplot.units.Rd
@@ -2,20 +2,20 @@
 % Please edit documentation in R/plot.R
 \name{boxplot.units}
 \alias{boxplot.units}
-\title{boxplot for unit objects}
+\title{Boxplot for \code{units} objects}
 \usage{
 \method{boxplot}{units}(x, ..., horizontal = FALSE)
 }
 \arguments{
-\item{x}{object of class units, for which we want to plot the boxplot}
+\item{x}{object of class \code{units}, for which we want to plot the boxplot}
 
-\item{...}{parameters passed on to \link{boxplot.default}}
+\item{...}{parameters passed on to \code{\link{boxplot.default}}}
 
-\item{horizontal}{logical indicating if the boxplots should be horizontal;
-default FALSE means vertical boxes.}
+\item{horizontal}{logical; whether boxplots should be horizontal;
+default \code{FALSE} means vertical boxes.}
 }
 \description{
-boxplot for unit objects
+Boxplot for \code{units} objects
 }
 \examples{
 units_options(parse = FALSE) # otherwise we break on the funny symbol!

--- a/man/convert_to_base.Rd
+++ b/man/convert_to_base.Rd
@@ -9,12 +9,12 @@ convert_to_base(x, simplify = TRUE, keep_fraction = TRUE)
 \arguments{
 \item{x}{object of class \code{units}.}
 
-\item{simplify}{logical; if TRUE (default), the resulting units are simplified.}
+\item{simplify}{logical; if \code{TRUE} (default), the resulting units are simplified.}
 
-\item{keep_fraction}{logical; if TRUE (default), the result is kept as a fraction.}
+\item{keep_fraction}{logical; if \code{TRUE} (default), the result is kept as a fraction.}
 }
 \value{
-object of class \code{units} with units converted to base units.
+An object of class \code{units} with units converted to base units.
 }
 \description{
 Convert the units of a \code{units} object to their base units, as defined by

--- a/man/hist.units.Rd
+++ b/man/hist.units.Rd
@@ -2,22 +2,22 @@
 % Please edit documentation in R/plot.R
 \name{hist.units}
 \alias{hist.units}
-\title{histogram for unit objects}
+\title{Histogram for \code{units} objects}
 \usage{
 \method{hist}{units}(x, xlab = NULL, main = paste("Histogram of", xname),
   ...)
 }
 \arguments{
-\item{x}{object of class units, for which we want to plot the histogram}
+\item{x}{object of class \code{units}, for which we want to plot the histogram}
 
 \item{xlab}{character; x axis label}
 
 \item{main}{character; title of histogram}
 
-\item{...}{parameters passed on to \link{hist.default}}
+\item{...}{parameters passed on to \code{\link{hist.default}}}
 }
 \description{
-histogram for unit objects
+Histogram for \code{units} objects
 }
 \examples{
 units_options(parse = FALSE) # otherwise we break on the funny symbol!

--- a/man/plot.units.Rd
+++ b/man/plot.units.Rd
@@ -11,22 +11,23 @@ make_unit_label(lab, u, sep = units_options("sep"),
 \method{plot}{units}(x, y, xlab = NULL, ylab = NULL, ...)
 }
 \arguments{
-\item{lab}{length one character; name of the variable to plot}
+\item{lab}{character; name of the variable to plot}
 
 \item{u}{vector of class \code{units}}
 
 \item{sep}{length two character vector, defaulting to \code{c("~","~")}, with
 the white space between unit name and unit symbols, and between subsequent
-symbols.}
+symbols}
 
 \item{group}{length two character vector with grouping symbols, e.g.
 \code{c("(",")")} for parenthesis, or \code{c("","")} for no group symbols}
 
 \item{parse}{logical; indicates whether a parseable expression should be
-returned (typically needed for super scripts), or a simple character string
-without special formatting.}
+returned (typically needed for superscripts), or a simple character string
+without special formatting}
 
-\item{x}{object of class units, to plot along the x axis, or, if y is missing, along the y axis}
+\item{x}{object of class \code{units}, to plot along the x axis or (if
+\code{y} is missing), along the y axis}
 
 \item{y}{object to plot along the y axis, or missing}
 
@@ -42,8 +43,8 @@ Create axis label with appropriate labels.
 Plot method for \code{units} objects.
 }
 \details{
-\link{units_options} can be used to set and change the defaults for
-  \code{sep}, \code{group} and \code{doParse}.
+\code{\link{units_options}} can be used to set and change the
+  defaults for \code{sep}, \code{group} and \code{doParse}.
 }
 \examples{
 displacement = mtcars$disp * as_units("in")^3
@@ -55,16 +56,16 @@ plot(weight, displacement)
 units_options(group = c("(", ")") )  # parenthesis instead of square brackets
 plot(weight, displacement)
 
-units_options(sep = c("~~~", "~"), group = c("", ""))  # no brackets; extra space
+units_options(sep = c("~~~", "~"), group = c("", ""))  # extra space; no brackets
 plot(weight, displacement)
 
 units_options(sep = c("~", "~~"), group = c("[", "]"))
 gallon = as_units("gallon")
 consumption = mtcars$mpg * make_units(mi/gallon)
 units(consumption) = make_units(km/l)
-plot(displacement, consumption) # division in consumption
+plot(displacement, consumption)  # division in consumption
 
-units_options(negative_power = TRUE) # division becomes ^-1
+units_options(negative_power = TRUE)  # division becomes ^-1
 plot(displacement, consumption)
 
 plot(1/displacement, 1/consumption)

--- a/man/units.Rd
+++ b/man/units.Rd
@@ -68,19 +68,19 @@ case of \code{set_units} expression with symbols (see examples).}
 \item{...}{passed on to other methods.}
 
 \item{mode}{if \code{"symbols"} (the default), then unit is constructed from
-the expression supplied. Otherwise, if\code{mode = "standard"},
-standard evaluation is used for the supplied value This argument can be set
-via a global option \code{units_options(set_units_mode = "standard")}}
+the expression supplied. Otherwise, if \code{mode = "standard"},
+standard evaluation is used for the supplied value. This argument can be set
+via a global option \code{units_options(set_units_mode = "standard")}.}
 
 \item{bare_expression}{a bare R expression describing units. Must be valid R
-syntax (reserved R syntax words like \code{in} must be backticked)}
+syntax (reserved R syntax words like \code{in} must be backticked).}
 
-\item{check_is_valid}{throw an error if all the unit symbols are not either
-recognized by udunits2, or a custom
-user defined via \code{install_unit()}. If \code{FALSE}, no check
+\item{check_is_valid}{throw an error if all the unit symbols are either not
+recognized by udunits2 or not custom units
+defined via \code{install_unit()}. If \code{FALSE}, no check
 for validity is performed.}
 
-\item{force_single_symbol}{Whether to perform no string parsing and force
+\item{force_single_symbol}{whether to perform no string parsing and force
 treatment of the string as a single symbol.}
 }
 \value{
@@ -102,18 +102,18 @@ A number of functions are provided for handling unit objects.
     \code{make_units(m/s)} is equivalent to \code{as_units(quote(m/s))}.
     \item \code{set_units}, a pipe-friendly version of \code{`units<-`}. By
     default it operates with bare expressions, but this
-    behavior can be disabled by a specifying \code{mode = "standard"} or setting
+    behavior can be disabled by specifying \code{mode = "standard"} or setting
     \code{units_options(set_units_mode = "standard")}.
     If \code{value} is missing or set to \code{1}, the object becomes unitless.
 }
 }
 \details{
 If \code{value} is of class \code{units} and has a value unequal to 1, this
-value is ignored unless \code{units_options("simplifiy")} is \code{TRUE}. If
+value is ignored unless \code{units_options("simplify")} is \code{TRUE}. If
 \code{simplify} is \code{TRUE}, \code{x} is multiplied by this value.
 }
 \note{
-By default, unit names are automatically substituted with unit names
+By default, unit names are automatically substituted with unit symbols
   (e.g., kilogram --> kg). To turn off this behavior, set
   \code{units_options(auto_convert_names_to_symbols = FALSE)}
 }
@@ -274,8 +274,10 @@ units(x) <- NULL
 set_units(x, NULL)
 # or
 drop_units(y)
+
+# Use difftime object as units
 s = Sys.time()
-d  = s - (s+1)
+d = s - (s+1)
 as_units(d)
 
 }

--- a/man/valid_udunits.Rd
+++ b/man/valid_udunits.Rd
@@ -10,29 +10,29 @@ valid_udunits(quiet = FALSE)
 valid_udunits_prefixes(quiet = FALSE)
 }
 \arguments{
-\item{quiet}{logical, defaults \code{TRUE} to give a message about the location of
+\item{quiet}{logical; \code{FALSE} (default) prints a message about the location of
 the udunits database being read.}
 }
 \value{
-a data frame with columns \code{symbol} , \code{symbol_aliases} ,
-  \code{name_singular} , \code{name_singular_aliases} , \code{name_plural} ,
-  or \code{name_plural_aliases} , \code{def} , \code{definition} ,
-  \code{comment} , \code{dimensionless} and \code{source_xml}
+A data frame with columns \code{symbol}, \code{symbol_aliases},
+  \code{name_singular}, \code{name_singular_aliases}, \code{name_plural},
+  \code{name_plural_aliases}, \code{def}, \code{definition},
+  \code{comment}, \code{dimensionless} and \code{source_xml}.
 }
 \description{
 These functions require the \pkg{xml2} package, and return data frames with
-complete information about pre-defined units from UDUNITS2. Inspect this data
-frames to determine what inputs are accepted by \code{as_units} (and the
-other functions it powers: \code{as_units}, \code{set_units} , \code{units<-}).
+complete information about pre-defined units from UDUNITS2. Inspect these
+data frames to determine what inputs are accepted by \code{as_units} (and the
+other functions it powers: \code{as_units}, \code{set_units}, \code{units<-}).
 }
 \details{
-Any entry listed under \code{symbol} , \code{symbol_aliases} , \code{
-name_singular} , \code{name_singular_aliases} , \code{name_plural} , or
+Any entry listed under \code{symbol}, \code{symbol_aliases},
+\code{name_singular}, \code{name_singular_aliases}, \code{name_plural} or
 \code{name_plural_aliases} is valid. Additionally, any entry under
-\code{symbol} or \code{symbol_aliases} may can also contain a valid prefix,
+\code{symbol} or \code{symbol_aliases} may also contain a valid prefix,
 as specified by \code{valid_udunits_prefixes()} .
 
-Note, this is primarily intended for interactive use, the exact format of the
+Note, this is primarily intended for interactive use. The exact format of the
 returned data frames may change in the future.
 }
 \examples{


### PR DESCRIPTION
Made some minor edits (spacing, punctuation, rearranged a few sentences, a few typos, etc.), mostly to documentation but also in a few code comments. No changes were made to any of the code in the package.

A few other notes:
1. I wasn't sure how important the max. line width of 80 characters was, so I wrapped some lines that extended beyond 80, but I mostly left others that already existed. However, it would probably be good to standardize this at some point.
2. I didn't change any code but there is inconsistent use of the assignment operators `<-` and `=` throughout the package. I don't feel strongly about it, so I defer to the package authors and maintainers. But again, it would be good to pick one style and use it consistently throughout the package.